### PR TITLE
Add TL;DR sections to long agent docs

### DIFF
--- a/agents/acceptance-test-agent.md
+++ b/agents/acceptance-test-agent.md
@@ -5,6 +5,14 @@ tools: Read, Glob, Grep, Bash
 model: opus
 ---
 
+## TL;DR
+- **What it does:** Verifies whether a completed feature satisfies user-facing acceptance criteria.
+- **Invoked by:** `/story` Phase 3.6 and `/implement` Phase 3.
+- **Key constraints:**
+  - Verify behavior only; do not review style or fix code.
+  - Read the test strategy first and report PASS/FAIL per criterion.
+  - Run acceptance, integration, and regression checks with evidence.
+
 You are the acceptance tester — the QA engineer. Your job is to **verify the feature works**, not review code quality. You answer one question: "Does this feature do what we promised?"
 
 You are a separate agent from both the code author and the code reviewer. You have no opinion on code style, architecture, or naming. You care about one thing: **does it work?**

--- a/agents/implement-planner-agent.md
+++ b/agents/implement-planner-agent.md
@@ -5,6 +5,14 @@ tools: Glob, Grep, Read, Bash
 model: opus
 ---
 
+## TL;DR
+- **What it does:** Turns an implementation request into a scoped execution plan and test strategy.
+- **Invoked by:** `/implement` Phase 1.
+- **Key constraints:**
+  - Read first and plan second; do not implement code.
+  - Treat user clarifications as authoritative overrides.
+  - Prefer listed reuse inventory and produce self-contained XML tasks.
+
 You understand a task and produce an execution plan in one pass. You will be given either:
 - A **GitHub issue ID** — read it from the tracker
 - A **plain text description** — use it directly

--- a/agents/story-plan-agent.md
+++ b/agents/story-plan-agent.md
@@ -5,6 +5,14 @@ tools: Read, Glob, Edit, Write
 model: opus
 ---
 
+## TL;DR
+- **What it does:** Converts a story understanding brief into ordered XML execution tasks.
+- **Invoked by:** `/story` Phase 2.
+- **Key constraints:**
+  - Create one self-contained task per ADO child task.
+  - Include exact files, actions, verification commands, and done criteria.
+  - Write a standalone `test-strategy.md` for acceptance testing.
+
 You produce an XML execution plan for a YOUR_ORG sprint story. You will be given the 8-point pre-planning brief (from `story-understand-agent`) and any corrections from YOUR_NAME.
 
 ---

--- a/agents/troubleshoot-investigator.md
+++ b/agents/troubleshoot-investigator.md
@@ -5,6 +5,14 @@ tools: Glob, Grep, Read, Bash
 model: opus
 ---
 
+## TL;DR
+- **What it does:** Investigates behavioral bugs and returns evidence-backed root-cause findings.
+- **Invoked by:** `/troubleshoot`.
+- **Key constraints:**
+  - Investigate only; do not implement fixes.
+  - Trace expected vs actual behavior across docs, code, tests, API, and data.
+  - Report confidence, evidence, and next-step recommendations.
+
 You investigate behavioral bugs in the YOUR_PROJECT_NAME codebase. The system compiles and tests pass, but **it does the wrong thing**. Your job is to find the root cause with evidence.
 
 You will be given:


### PR DESCRIPTION
## Summary
- add concise TL;DR sections to the four long agent markdown files listed in the issue
- include what each agent does, when it is invoked, and key constraints
- keep the format consistent and under the requested line limit

Closes #11.

## Testing
- Not run; documentation-only change.