### PR TITLE
chore: add missing Python dev artifact patterns to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,14 @@ __pycache__/
 *.pyc
 .venv/
 venv/
+*.egg-info/
+*.egg
+dist/
+build/
+.pytest_cache/
+.coverage
+htmlcov/
+.ruff_cache/
 
 # Secrets
 .env


### PR DESCRIPTION
## Summary
- Add packaging (`*.egg-info/`, `*.egg`, `dist/`, `build/`), testing (`.pytest_cache/`, `.coverage`, `htmlcov/`), and linting (`.ruff_cache/`) patterns to the existing Python section in `.gitignore`

## Test plan
- [ ] Verify no tracked files are affected by the new patterns (`git ls-files -i --exclude-standard`)