### PR TITLE
#18 Add contextual SessionStart guidance based on project state

### DIFF
--- a/hooks/__tests__/session-router.test.js
+++ b/hooks/__tests__/session-router.test.js
@@ -1,0 +1,83 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+const { renderGuidance, detectFirstOpenIssue } = require('../lib/project-state.js');
+
+// 1. Greenfield state suggests /grill-me and does NOT suggest /implement
+test('renderGuidance_GreenfieldState_SuggestsGrillMe', () => {
+  const msg = renderGuidance('greenfield', { artifacts: [], openIssues: 0, ghAvailable: true }, null);
+  assert.ok(msg.includes('/grill-me'), 'expected /grill-me in message');
+  assert.ok(!msg.includes('/implement'), 'expected /implement NOT in message');
+});
+
+// 2. Active state with first issue shows issue number, title, and /implement
+test('renderGuidance_ActiveWithFirstIssue_ShowsIssueNumberTitleAndImplement', () => {
+  const msg = renderGuidance('active', { artifacts: [], openIssues: 1, ghAvailable: true }, { number: 18, title: 'Show contextual guidance' });
+  assert.ok(msg.includes('#18'), 'expected #18 in message');
+  assert.ok(msg.includes('Show contextual guidance'), 'expected title in message');
+  assert.ok(msg.includes('/implement'), 'expected /implement in message');
+});
+
+// 3. Active state with artifact and no issue suggests /plan and lists artifact
+test('renderGuidance_ActiveArtifactNoIssue_SuggestsPlanAndListsArtifact', () => {
+  const msg = renderGuidance('active', { artifacts: ['grill-summary.md'], openIssues: null, ghAvailable: false }, null);
+  assert.ok(msg.includes('/plan'), 'expected /plan in message');
+  assert.ok(msg.includes('grill-summary.md'), 'expected artifact name in message');
+});
+
+// 3b. Active state renders without throwing when signals.artifacts is missing (defensive guard)
+test('renderGuidance_ActiveSignalsMissingArtifacts_DoesNotThrow', () => {
+  let msg;
+  assert.doesNotThrow(() => {
+    msg = renderGuidance('active', { openIssues: null, ghAvailable: false }, null);
+  }, 'renderGuidance must not throw when signals.artifacts is undefined');
+  assert.ok(msg.includes('/plan'), 'expected /plan in fallback message');
+});
+
+// 4. Greenfield message is under five lines
+test('renderGuidance_GreenfieldMessage_IsUnderFiveLines', () => {
+  const msg = renderGuidance('greenfield', { artifacts: [], openIssues: 0, ghAvailable: true }, null);
+  const lineCount = msg.split('\n').length;
+  assert.ok(lineCount < 5, `expected < 5 lines, got ${lineCount}`);
+});
+
+// 5. Active message variants are each under five lines
+test('renderGuidance_ActiveMessage_IsUnderFiveLines', () => {
+  const withIssue = renderGuidance('active', { artifacts: [], openIssues: 1, ghAvailable: true }, { number: 18, title: 'Show contextual guidance' });
+  const withIssueLines = withIssue.split('\n').length;
+  assert.ok(withIssueLines < 5, `active-with-issue: expected < 5 lines, got ${withIssueLines}`);
+
+  const artifactOnly = renderGuidance('active', { artifacts: ['grill-summary.md'], openIssues: null, ghAvailable: false }, null);
+  const artifactOnlyLines = artifactOnly.split('\n').length;
+  assert.ok(artifactOnlyLines < 5, `active-artifact-only: expected < 5 lines, got ${artifactOnlyLines}`);
+});
+
+// 6. detectFirstOpenIssue returns number and title when runner returns a valid issue array
+test('detectFirstOpenIssue_RunnerReturnsIssue_ReturnsNumberAndTitle', () => {
+  const result = detectFirstOpenIssue({ firstIssueRunner: () => JSON.stringify([{ number: 7, title: 'Foo' }]) });
+  assert.deepEqual(result, { number: 7, title: 'Foo' });
+});
+
+// 7. detectFirstOpenIssue fails open and returns null when runner throws
+test('detectFirstOpenIssue_RunnerThrows_FailsOpenReturnsNull', () => {
+  let result;
+  assert.doesNotThrow(() => {
+    result = detectFirstOpenIssue({ firstIssueRunner: () => { throw new Error('gh not found'); } });
+  });
+  assert.equal(result, null);
+});
+
+// 8. detectFirstOpenIssue returns null when runner returns empty array
+test('detectFirstOpenIssue_RunnerReturnsEmptyArray_ReturnsNull', () => {
+  const result = detectFirstOpenIssue({ firstIssueRunner: () => '[]' });
+  assert.equal(result, null);
+});
+
+// 9. detectFirstOpenIssue returns null when runner returns non-JSON
+test('detectFirstOpenIssue_RunnerReturnsNonJson_FailsOpenReturnsNull', () => {
+  let result;
+  assert.doesNotThrow(() => {
+    result = detectFirstOpenIssue({ firstIssueRunner: () => 'garbage{{{' });
+  });
+  assert.equal(result, null);
+});

--- a/hooks/lib/project-state.js
+++ b/hooks/lib/project-state.js
@@ -25,6 +25,14 @@ function defaultGhRunner() {
   );
 }
 
+function defaultFirstIssueRunner() {
+  return execFileSync(
+    'gh',
+    ['issue', 'list', '--state', 'open', '--limit', '1', '--json', 'number,title'],
+    { encoding: 'utf8', timeout: 1500, stdio: ['ignore', 'pipe', 'ignore'] }
+  );
+}
+
 // Probe the gh CLI for open issues. Returns { openIssues, ghAvailable }.
 // Never throws — any failure yields { openIssues: null, ghAvailable: false }.
 function detectOpenIssues(opts) {
@@ -37,6 +45,45 @@ function detectOpenIssues(opts) {
   } catch {
     return { openIssues: null, ghAvailable: false };
   }
+}
+
+// Probe the gh CLI for the first open issue. Returns { number, title } or null.
+// Never throws — any failure yields null.
+function detectFirstOpenIssue(opts) {
+  const runner = (opts && opts.firstIssueRunner) ? opts.firstIssueRunner : defaultFirstIssueRunner;
+  try {
+    const raw = runner();
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed) || parsed.length < 1) return null;
+    return { number: parsed[0].number, title: parsed[0].title };
+  } catch {
+    return null;
+  }
+}
+
+// Pure function: produce a human-readable guidance string based on project state.
+// state    — 'greenfield' or 'active'
+// signals  — { artifacts, openIssues, ghAvailable }
+// firstIssue — { number, title } or null
+function renderGuidance(state, signals, firstIssue) {
+  if (state === 'greenfield') {
+    return (
+      'Project looks greenfield — no planning artifacts or open issues detected.\n' +
+      'Have an idea? Start with /grill-me to pressure-test it into a spec, then /plan.'
+    );
+  }
+  if (firstIssue !== null && firstIssue !== undefined) {
+    return (
+      'Active project — open issues detected.\n' +
+      'Next: /implement #' + firstIssue.number + ' (' + firstIssue.title + ')\n' +
+      'Or run /plan to break down work before implementing.'
+    );
+  }
+  const artifacts = (signals && signals.artifacts) || [];
+  return (
+    'Active project — planning artifacts detected (' + artifacts.join(', ') + ').\n' +
+    'Next: /plan to break work into issues, or /implement once issues exist.'
+  );
 }
 
 // Detect whether projectRoot looks greenfield or active.
@@ -72,4 +119,6 @@ function detectProjectState(projectRoot, opts) {
 module.exports = {
   detectProjectState,
   detectOpenIssues,
+  detectFirstOpenIssue,
+  renderGuidance,
 };

--- a/hooks/session-router.js
+++ b/hooks/session-router.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+// SessionStart hook — prints contextual next-step guidance based on detected
+// project state (greenfield vs active). Reads planning artifacts and open
+// GitHub issues to determine which state applies, then injects a short prompt
+// nudging the developer toward the right next action.
+//
+// Fail-open: if project state can't be determined, the session starts normally.
+
+const { execFileSync } = require('node:child_process');
+const { readStdinJson, injectContext, ok, runHook } = require('./lib/hook-io');
+const { detectProjectState, detectFirstOpenIssue, renderGuidance } = require('./lib/project-state');
+
+function git(args) {
+  try { return execFileSync('git', args, { encoding: 'utf8' }).trim(); }
+  catch { return ''; }
+}
+
+runHook('session-router', async () => {
+  await readStdinJson();
+  const projectRoot = git(['rev-parse', '--show-toplevel']) || process.cwd();
+  const { state, signals } = detectProjectState(projectRoot);
+  // Only fetch the first issue when detection already confirmed an open issue
+  // exists (signals.openIssues >= 1). This skips a redundant ~1.5s gh subprocess
+  // for active-by-artifact projects and when gh is unavailable (openIssues null).
+  let firstIssue = null;
+  if (state === 'active' && signals.openIssues >= 1) firstIssue = detectFirstOpenIssue();
+  const message = renderGuidance(state, signals, firstIssue);
+  if (!message) return ok();
+  injectContext('SessionStart', '## Next step\n' + message);
+});

--- a/install/__tests__/substitute.test.js
+++ b/install/__tests__/substitute.test.js
@@ -184,6 +184,21 @@ test('buildSettings_HookCommandsReferenceHooksUnix', () => {
   assert.equal(safety, 'node "/my/hooks/safety-check.js"');
 });
 
+test('buildSettings_SessionStart_IncludesRouterAndPreservesEchoAndContext', () => {
+  const s = buildSettings({
+    hooksUnix: '/h',
+    workflowPack: 'solo',
+    sessionStartMsg: 'hi',
+    workRoot: '',
+    isGlobal: false,
+  });
+  const cmds = s.hooks.SessionStart[0].hooks.map(h => h.command);
+  assert.ok(cmds.some(c => /echo "hi"/.test(c)), 'echo preserved');
+  assert.ok(cmds.includes('node "/h/session-context.js"'), 'session-context hook preserved');
+  assert.ok(cmds.includes('node "/h/session-router.js"'), 'session-router wired');
+  assert.equal(cmds.length, 3);
+});
+
 test('buildSettings_SerializesToValidJson', () => {
   // Guard: if someone accidentally injects an unescaped backslash via template
   // interpolation, JSON.stringify would throw or produce invalid output.

--- a/install/install.js
+++ b/install/install.js
@@ -586,6 +586,7 @@ function buildSettings({ hooksUnix, sessionStartMsg, workRoot, isGlobal }) {
       SessionStart: [{ matcher: '*', hooks: [
         { type: 'command', command: `echo "${sessionStartMsg}"` },
         { type: 'command', command: nodeCmd('session-context.js') },
+        { type: 'command', command: nodeCmd('session-router.js') },
       ] }],
       SessionEnd: [{ matcher: '*', hooks: [{ type: 'command', command: nodeCmd('session-log.js') }] }],
     },


### PR DESCRIPTION
## Summary
- Adds `renderGuidance` and `detectFirstOpenIssue` to the project-state library so the harness produces a human-readable "next step" nudge at session start — directing the developer toward `/grill-me` (greenfield), `/implement #N` (active with an open issue), or `/plan` (active, no issues yet).
- Adds `hooks/session-router.js`, a new SessionStart hook: probes project state, conditionally fetches the first open issue only when one is already confirmed (`openIssues >= 1`, avoiding a redundant ~1.5s subprocess), renders guidance, and injects it via `injectContext`. Fails open so session start is never blocked.
- Wires `session-router.js` into `install.js buildSettings()` so it ships automatically alongside the existing echo and `session-context.js` hooks; adds a regression-guard test asserting the 3-hook array.

## Stacked PR note
**Base branch: `implement/17-greenfield-detection` (PR #20), NOT `main`.** This branch depends on `detectProjectState`/`detectOpenIssues` from #17. Once PR #20 merges to main, retarget this PR to `main` before merging.

## How to verify
1. Feature suite: `node --test hooks/__tests__/session-router.test.js hooks/__tests__/project-state.test.js install/__tests__/substitute.test.js` -> 37/37 pass.
2. Full suite: `npm test` -> 190 pass / 5 fail. The 5 failures are pre-existing and unrelated to #18 (4 in install/__tests__/non-interactive.test.js, 1 in trackers/__tests__/conformance.test.js).
3. Greenfield scratch dir (no PRD.md/ARCHITECTURE.md/etc., no open issues) -> injected `## Next step` references `/grill-me`.
4. Active project with an open issue -> message references `/implement #<N> (<title>)`.

## Test results
Tests: 37/37 feature suite | 190 pass / 5 fail full suite (5 pre-existing, unrelated).

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)