### PR TITLE
feat: make Todoist a first-class tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). This project adh
 
 ### New skills
 
-- `/to-todoist` — Decompose planning artifacts into Todoist milestones and tasks via the `td` CLI. Milestones as uncompletable parent tasks, work items as prioritized subtasks with descriptions, acceptance criteria, and dependency notes. Supports `--project`, `--section`, and `--dry-run` flags. Reads defaults from `tasks/notes.md` Todoist section.
+- `/to-todoist` — Decompose planning artifacts into Todoist milestones and tasks. Milestones as uncompletable parent tasks, work items as prioritized subtasks with descriptions, acceptance criteria, and dependency notes. Supports `--project`, `--section`, and `--dry-run` flags. Reads defaults from `tasks/notes.md` Todoist section.
+
+### Tracker integration
+
+- **Todoist tracker adapter** — Full 9-script adapter in `trackers/todoist/` implementing the same interface as GitHub and ADO. Resolves `td` CLI from `$TODOIST_CLI` or `$PATH`.
+- **Tracker-agnostic session routing** — `session-router.js` and `project-state.js` now detect which tracker is active (GitHub, ADO, or Todoist) and route accordingly. Projects using Todoist get task-based guidance instead of issue-based.
+- **Installer Todoist support** — Both solo and enterprise workflow packs now offer Todoist as a tracker option during installation.
+- **`/implement` Todoist support** — Accepts Todoist task titles and IDs in addition to GitHub issue numbers. Fetches task context from the active tracker adapter.
+- **`/grill-me` downstream routing** — Now recommends `/to-todoist` alongside `/to-issues` as a downstream skill.
+- **`tracker-config.md` template** — Includes Todoist settings (`todoist_project`, `todoist_default_section`).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Skills are invoked with `/skill-name` in Claude Code. Each skill is a folder und
 | **decision-brief** | `/decision-brief` | Pre-PRD assumption pass — 4 inline phases produce a Decision Brief with tiered evidence thresholds and a risk-ranked test plan |
 | **prd-critique** | `/prd-critique <path> [--brief <path>]` | Run 6 critique checks on a PRD — metric validity, NFR specificity, failure modes, assumption traceability, rollback plan, intent clarity. Read-only |
 | **to-issues** | `/to-issues <prd>` | Decompose a PRD into vertical-slice tracker issues — each slice is end-to-end demoable with Given/When/Then acceptance criteria |
-| **to-todoist** | `/to-todoist --project "X" --section "Y"` | Decompose planning artifacts into Todoist milestones and tasks via the `td` CLI — milestones as uncompletable parents, tasks as prioritized subtasks |
+| **to-todoist** | `/to-todoist --project "X" --section "Y"` | Decompose planning artifacts into Todoist milestones and tasks — milestones as uncompletable parents, tasks as prioritized subtasks. Full tracker adapter integration (session routing, `/plan`, `/implement`) |
 | **grill-with-docs** | `/grill-with-docs <plan or design>` | Like /grill-me but anchored in CONTEXT.md and ADRs — challenges vague terms against the glossary, surfaces plan-vs-decision contradictions, updates CONTEXT.md with resolved terms |
 | **research** | `/research <topic> [--urls ...]` | Research an external API, integration, or library — caches provenance-tagged findings in research.md for downstream agents to read |
 | **architect** | `/architect <path-to-PRD>` | Design system architecture from a PRD — interactive 8-section ARCHITECTURE.md with Mermaid diagrams, cost model, and compliance gates |

--- a/hooks/__tests__/project-state.test.js
+++ b/hooks/__tests__/project-state.test.js
@@ -5,7 +5,13 @@ const os = require('node:os');
 const path = require('node:path');
 const { performance } = require('node:perf_hooks');
 
-const { detectProjectState, detectOpenIssues } = require('../lib/project-state.js');
+const {
+  detectProjectState,
+  detectActiveTracker,
+  detectOpenIssues,
+  detectFirstOpenIssue,
+  renderGuidance,
+} = require('../lib/project-state.js');
 
 function makeProjectRoot() {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'project-state-'));
@@ -28,7 +34,7 @@ test('detectProjectState_NoArtifactsNoIssues_ReturnsGreenfield', () => {
     assert.equal(result.state, 'greenfield');
     assert.deepEqual(result.signals.artifacts, []);
     assert.equal(result.signals.openIssues, 0);
-    assert.equal(result.signals.ghAvailable, true);
+    assert.equal(result.signals.trackerAvailable, true);
   } finally { cleanup(root); }
 });
 
@@ -50,7 +56,7 @@ test('detectProjectState_OneOpenIssue_ReturnsActive', () => {
     const result = detectProjectState(root, { ghRunner: ghReturns([{ number: 42 }]) });
     assert.equal(result.state, 'active');
     assert.equal(result.signals.openIssues, 1);
-    assert.equal(result.signals.ghAvailable, true);
+    assert.equal(result.signals.trackerAvailable, true);
   } finally { cleanup(root); }
 });
 
@@ -122,7 +128,7 @@ test('detectProjectState_GhRunnerThrows_FailsOpen', () => {
     });
     assert.equal(result.state, 'greenfield');
     assert.equal(result.signals.openIssues, null);
-    assert.equal(result.signals.ghAvailable, false);
+    assert.equal(result.signals.trackerAvailable, false);
   } finally { cleanup(root); }
 });
 
@@ -136,7 +142,7 @@ test('detectProjectState_GhReturnsNonJson_FailsOpen', () => {
       result = detectProjectState(root, { ghRunner: badRunner });
     });
     assert.equal(result.signals.openIssues, null);
-    assert.equal(result.signals.ghAvailable, false);
+    assert.equal(result.signals.trackerAvailable, false);
   } finally { cleanup(root); }
 });
 
@@ -155,19 +161,155 @@ test('detectProjectState_WithInjectedRunner_CompletesUnder500ms', () => {
 test('detectOpenIssues_RunnerReturnsArray_ReturnsCountAndAvailable', () => {
   const result = detectOpenIssues({ ghRunner: ghReturns([{ number: 1 }, { number: 2 }]) });
   assert.equal(result.openIssues, 2);
-  assert.equal(result.ghAvailable, true);
+  assert.equal(result.trackerAvailable, true);
 });
 
 // detectOpenIssues: runner returns non-array JSON -> fail-open
 test('detectOpenIssues_RunnerReturnsNonArray_FailsOpen', () => {
   const result = detectOpenIssues({ ghRunner: () => '{"not":"array"}' });
   assert.equal(result.openIssues, null);
-  assert.equal(result.ghAvailable, false);
+  assert.equal(result.trackerAvailable, false);
 });
 
 // detectOpenIssues: runner throws -> fail-open
 test('detectOpenIssues_RunnerThrows_FailsOpen', () => {
   const result = detectOpenIssues({ ghRunner: () => { throw new Error('no gh'); } });
   assert.equal(result.openIssues, null);
-  assert.equal(result.ghAvailable, false);
+  assert.equal(result.trackerAvailable, false);
+});
+
+// ── Todoist-specific tests ──────────────────────────────────────────────
+
+function tdReturns(json) {
+  return () => JSON.stringify(json);
+}
+
+// detectActiveTracker: reads Type field from tracker-config.md
+test('detectActiveTracker_TrackerConfigTodoist_ReturnsTodoist', () => {
+  const root = makeProjectRoot();
+  try {
+    fs.mkdirSync(path.join(root, 'tasks'));
+    fs.writeFileSync(path.join(root, 'tasks', 'tracker-config.md'), '**Type:** Todoist\n');
+    const tracker = detectActiveTracker(root);
+    assert.equal(tracker, 'todoist');
+  } finally { cleanup(root); }
+});
+
+// detectActiveTracker: explicit override via opts.tracker
+test('detectActiveTracker_ExplicitOverride_ReturnsOverride', () => {
+  const root = makeProjectRoot();
+  try {
+    const tracker = detectActiveTracker(root, { tracker: 'todoist' });
+    assert.equal(tracker, 'todoist');
+  } finally { cleanup(root); }
+});
+
+// detectProjectState with Todoist: open tasks detected
+test('detectProjectState_TodoistWithOpenTasks_ReturnsActive', () => {
+  const root = makeProjectRoot();
+  try {
+    const tasks = [
+      { id: '100', content: 'Build login', is_completed: false },
+      { id: '101', content: 'Done task', is_completed: true },
+    ];
+    const result = detectProjectState(root, {
+      tracker: 'todoist',
+      tdRunner: tdReturns(tasks),
+    });
+    assert.equal(result.state, 'active');
+    assert.equal(result.signals.openIssues, 1);
+    assert.equal(result.signals.tracker, 'todoist');
+  } finally { cleanup(root); }
+});
+
+// detectProjectState with Todoist: no open tasks, no artifacts -> greenfield
+test('detectProjectState_TodoistNoOpenTasks_ReturnsGreenfield', () => {
+  const root = makeProjectRoot();
+  try {
+    const tasks = [{ id: '100', content: 'Done', is_completed: true }];
+    const result = detectProjectState(root, {
+      tracker: 'todoist',
+      tdRunner: tdReturns(tasks),
+    });
+    assert.equal(result.state, 'greenfield');
+    assert.equal(result.signals.openIssues, 0);
+  } finally { cleanup(root); }
+});
+
+// detectOpenIssues with Todoist: counts only non-completed tasks
+test('detectOpenIssues_Todoist_CountsOpenOnly', () => {
+  const tasks = [
+    { id: '1', content: 'A', is_completed: false },
+    { id: '2', content: 'B', is_completed: true },
+    { id: '3', content: 'C', is_completed: false },
+  ];
+  const result = detectOpenIssues({
+    activeTracker: 'todoist',
+    tdRunner: tdReturns(tasks),
+  });
+  assert.equal(result.openIssues, 2);
+  assert.equal(result.trackerAvailable, true);
+});
+
+// detectOpenIssues with Todoist: runner throws -> fail-open
+test('detectOpenIssues_TodoistRunnerThrows_FailsOpen', () => {
+  const result = detectOpenIssues({
+    activeTracker: 'todoist',
+    tdRunner: () => { throw new Error('no td'); },
+  });
+  assert.equal(result.openIssues, null);
+  assert.equal(result.trackerAvailable, false);
+});
+
+// detectFirstOpenIssue with Todoist: returns first open task
+test('detectFirstOpenIssue_Todoist_ReturnsFirstOpenTask', () => {
+  const tasks = [
+    { id: '50', content: 'Completed', is_completed: true },
+    { id: '51', content: 'Build API', is_completed: false },
+    { id: '52', content: 'Build UI', is_completed: false },
+  ];
+  const result = detectFirstOpenIssue({
+    activeTracker: 'todoist',
+    firstTodoistTaskRunner: tdReturns(tasks),
+  });
+  assert.deepEqual(result, { id: '51', title: 'Build API' });
+});
+
+// detectFirstOpenIssue with Todoist: no open tasks -> null
+test('detectFirstOpenIssue_TodoistAllCompleted_ReturnsNull', () => {
+  const tasks = [{ id: '50', content: 'Done', is_completed: true }];
+  const result = detectFirstOpenIssue({
+    activeTracker: 'todoist',
+    firstTodoistTaskRunner: tdReturns(tasks),
+  });
+  assert.equal(result, null);
+});
+
+// renderGuidance: Todoist active with first task
+test('renderGuidance_TodoistWithFirstTask_ShowsTaskTitle', () => {
+  const msg = renderGuidance(
+    'active',
+    { tracker: 'todoist', openIssues: 1 },
+    { id: '51', title: 'Build API' }
+  );
+  assert.ok(msg.includes('/implement "Build API"'), 'should suggest /implement with task title');
+  assert.ok(msg.includes('Todoist'), 'should mention Todoist');
+  assert.ok(!msg.includes('#'), 'should not use # issue number syntax');
+});
+
+// renderGuidance: GitHub active with first issue (unchanged behavior)
+test('renderGuidance_GitHubWithFirstIssue_ShowsIssueNumber', () => {
+  const msg = renderGuidance(
+    'active',
+    { tracker: 'github', openIssues: 1 },
+    { number: 42, title: 'Login flow' }
+  );
+  assert.ok(msg.includes('/implement #42'), 'should suggest /implement with issue number');
+});
+
+// renderGuidance: greenfield message is tracker-neutral
+test('renderGuidance_Greenfield_TrackerNeutral', () => {
+  const msg = renderGuidance('greenfield', { tracker: 'todoist' }, null);
+  assert.ok(msg.includes('greenfield'), 'should say greenfield');
+  assert.ok(msg.includes('/grill-me'), 'should suggest /grill-me');
 });

--- a/hooks/lib/project-state.js
+++ b/hooks/lib/project-state.js
@@ -1,7 +1,10 @@
 // Project-state detection — determines whether a project root looks like a
 // fresh greenfield workspace or an active one with prior planning artifacts.
 //
-// Fail-open philosophy: every boundary (filesystem, gh CLI) is wrapped in
+// Tracker-agnostic: detects which tracker adapter is installed (GitHub, ADO,
+// Todoist) and probes for open tasks accordingly.
+//
+// Fail-open philosophy: every boundary (filesystem, CLI) is wrapped in
 // try/catch. On any error the signal is simply absent; we never throw and
 // never block the caller. The returned `state` therefore leans toward
 // 'greenfield' when evidence is unclear, which is the safer default.
@@ -17,11 +20,69 @@ const DEFAULT_ARTIFACT_PATHS = [
   'tasks/plan.md',
 ];
 
+// Detect which tracker is active by reading tracker-config.md or probing
+// which CLIs are available. Returns 'github' | 'todoist' | 'ado' | null.
+function detectActiveTracker(projectRoot, opts) {
+  const options = opts || {};
+
+  if (options.tracker) return options.tracker;
+
+  // Check tracker-config.md for explicit Type field
+  try {
+    const configPath = path.join(projectRoot, 'tasks', 'tracker-config.md');
+    if (fs.existsSync(configPath)) {
+      const content = fs.readFileSync(configPath, 'utf8');
+      const match = content.match(/\*\*Type:\*\*\s*\[?\s*(GitHub|Todoist|ADO|Azure DevOps)\s*\]?/i);
+      if (match) {
+        const raw = match[1].toLowerCase();
+        if (raw === 'todoist') return 'todoist';
+        if (raw === 'github') return 'github';
+        if (raw === 'ado' || raw === 'azure devops') return 'ado';
+      }
+    }
+  } catch { /* fail-open */ }
+
+  // Check which tracker adapter scripts exist
+  try {
+    const activePath = path.join(projectRoot, '.claude', 'trackers', 'active');
+    if (fs.existsSync(activePath)) {
+      const scripts = fs.readdirSync(activePath);
+      // Todoist adapter scripts reference td CLI; check for TODOIST_CLI marker
+      for (const script of scripts) {
+        try {
+          const content = fs.readFileSync(path.join(activePath, script), 'utf8');
+          if (content.includes('TODOIST_CLI') || content.includes('check_auth_todoist')) return 'todoist';
+          if (content.includes('check_auth_ado')) return 'ado';
+        } catch { /* ignore individual file errors */ }
+      }
+      // Default to github if adapter scripts exist but no Todoist/ADO markers
+      return 'github';
+    }
+  } catch { /* fail-open */ }
+
+  // Probe CLI availability as last resort
+  try {
+    execFileSync('gh', ['--version'], { encoding: 'utf8', timeout: 1000, stdio: 'ignore' });
+    return 'github';
+  } catch { /* not available */ }
+
+  return null;
+}
+
 function defaultGhRunner() {
   return execFileSync(
     'gh',
     ['issue', 'list', '--state', 'open', '--limit', '1', '--json', 'number'],
     { encoding: 'utf8', timeout: 1500, stdio: ['ignore', 'pipe', 'ignore'] }
+  );
+}
+
+function defaultTdRunner() {
+  const td = process.env.TODOIST_CLI || 'td';
+  return execFileSync(
+    td,
+    ['task', 'list', '--json'],
+    { encoding: 'utf8', timeout: 3000, stdio: ['ignore', 'pipe', 'ignore'] }
   );
 }
 
@@ -33,24 +94,69 @@ function defaultFirstIssueRunner() {
   );
 }
 
-// Probe the gh CLI for open issues. Returns { openIssues, ghAvailable }.
-// Never throws — any failure yields { openIssues: null, ghAvailable: false }.
+function defaultFirstTodoistTaskRunner() {
+  const td = process.env.TODOIST_CLI || 'td';
+  return execFileSync(
+    td,
+    ['task', 'list', '--json'],
+    { encoding: 'utf8', timeout: 3000, stdio: ['ignore', 'pipe', 'ignore'] }
+  );
+}
+
+// Probe for open issues/tasks. Returns { openIssues, trackerAvailable }.
+// Never throws — any failure yields { openIssues: null, trackerAvailable: false }.
 function detectOpenIssues(opts) {
-  const ghRunner = (opts && opts.ghRunner) ? opts.ghRunner : defaultGhRunner;
+  const options = opts || {};
+  const tracker = options.activeTracker || 'github';
+
+  if (tracker === 'todoist') {
+    const tdRunner = options.tdRunner || defaultTdRunner;
+    try {
+      const raw = tdRunner();
+      const parsed = JSON.parse(raw);
+      if (!Array.isArray(parsed)) return { openIssues: null, trackerAvailable: false };
+      const openTasks = parsed.filter(function(t) { return !t.is_completed; });
+      return { openIssues: openTasks.length, trackerAvailable: true };
+    } catch {
+      return { openIssues: null, trackerAvailable: false };
+    }
+  }
+
+  // GitHub / ADO default path
+  const ghRunner = options.ghRunner || defaultGhRunner;
   try {
     const raw = ghRunner();
     const parsed = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return { openIssues: null, ghAvailable: false };
-    return { openIssues: parsed.length, ghAvailable: true };
+    if (!Array.isArray(parsed)) return { openIssues: null, trackerAvailable: false };
+    return { openIssues: parsed.length, trackerAvailable: true };
   } catch {
-    return { openIssues: null, ghAvailable: false };
+    return { openIssues: null, trackerAvailable: false };
   }
 }
 
-// Probe the gh CLI for the first open issue. Returns { number, title } or null.
+// Probe for the first open issue/task. Returns { number, title } or null.
+// For Todoist, returns { id, title } instead.
 // Never throws — any failure yields null.
 function detectFirstOpenIssue(opts) {
-  const runner = (opts && opts.firstIssueRunner) ? opts.firstIssueRunner : defaultFirstIssueRunner;
+  const options = opts || {};
+  const tracker = options.activeTracker || 'github';
+
+  if (tracker === 'todoist') {
+    const runner = options.firstTodoistTaskRunner || defaultFirstTodoistTaskRunner;
+    try {
+      const raw = runner();
+      const parsed = JSON.parse(raw);
+      if (!Array.isArray(parsed) || parsed.length < 1) return null;
+      const openTasks = parsed.filter(function(t) { return !t.is_completed; });
+      if (openTasks.length < 1) return null;
+      return { id: openTasks[0].id, title: openTasks[0].content };
+    } catch {
+      return null;
+    }
+  }
+
+  // GitHub default
+  const runner = options.firstIssueRunner || defaultFirstIssueRunner;
   try {
     const raw = runner();
     const parsed = JSON.parse(raw);
@@ -63,16 +169,25 @@ function detectFirstOpenIssue(opts) {
 
 // Pure function: produce a human-readable guidance string based on project state.
 // state    — 'greenfield' or 'active'
-// signals  — { artifacts, openIssues, ghAvailable }
-// firstIssue — { number, title } or null
+// signals  — { artifacts, openIssues, trackerAvailable, tracker }
+// firstIssue — { number, title } (GitHub) or { id, title } (Todoist) or null
 function renderGuidance(state, signals, firstIssue) {
+  const tracker = (signals && signals.tracker) || 'github';
+
   if (state === 'greenfield') {
     return (
-      'Project looks greenfield — no planning artifacts or open issues detected.\n' +
+      'Project looks greenfield — no planning artifacts or open tasks detected.\n' +
       'Have an idea? Start with /grill-me to pressure-test it into a spec, then /plan.'
     );
   }
   if (firstIssue !== null && firstIssue !== undefined) {
+    if (tracker === 'todoist') {
+      return (
+        'Active project — open Todoist tasks detected.\n' +
+        'Next: /implement "' + firstIssue.title + '"\n' +
+        'Or run /plan to prioritize work before implementing.'
+      );
+    }
     return (
       'Active project — open issues detected.\n' +
       'Next: /implement #' + firstIssue.number + ' (' + firstIssue.title + ')\n' +
@@ -82,20 +197,22 @@ function renderGuidance(state, signals, firstIssue) {
   const artifacts = (signals && signals.artifacts) || [];
   return (
     'Active project — planning artifacts detected (' + artifacts.join(', ') + ').\n' +
-    'Next: /plan to break work into issues, or /implement once issues exist.'
+    'Next: /plan to break work into tasks, or /implement once tasks exist.'
   );
 }
 
 // Detect whether projectRoot looks greenfield or active.
 // opts.artifactPaths  — override the default set of relative paths to probe
 // opts.ghRunner       — injectable replacement for the gh execFileSync call
+// opts.tdRunner       — injectable replacement for the td execFileSync call
+// opts.tracker        — force a specific tracker type
 function detectProjectState(projectRoot, opts) {
   const options = opts || {};
   const artifactPaths = Array.isArray(options.artifactPaths)
     ? options.artifactPaths
     : DEFAULT_ARTIFACT_PATHS;
 
-  const artifacts = artifactPaths.filter((rel) => {
+  const artifacts = artifactPaths.filter(function(rel) {
     try {
       return fs.existsSync(path.join(projectRoot, rel));
     } catch {
@@ -103,7 +220,11 @@ function detectProjectState(projectRoot, opts) {
     }
   });
 
-  const { openIssues, ghAvailable } = detectOpenIssues(options);
+  const tracker = detectActiveTracker(projectRoot, options);
+  const { openIssues, trackerAvailable } = detectOpenIssues({
+    ...options,
+    activeTracker: tracker,
+  });
 
   const state =
     artifacts.length > 0 || (openIssues !== null && openIssues >= 1)
@@ -112,12 +233,13 @@ function detectProjectState(projectRoot, opts) {
 
   return {
     state,
-    signals: { artifacts, openIssues, ghAvailable },
+    signals: { artifacts, openIssues, trackerAvailable, tracker },
   };
 }
 
 module.exports = {
   detectProjectState,
+  detectActiveTracker,
   detectOpenIssues,
   detectFirstOpenIssue,
   renderGuidance,

--- a/hooks/session-router.js
+++ b/hooks/session-router.js
@@ -19,11 +19,13 @@ runHook('session-router', async () => {
   await readStdinJson();
   const projectRoot = git(['rev-parse', '--show-toplevel']) || process.cwd();
   const { state, signals } = detectProjectState(projectRoot);
-  // Only fetch the first issue when detection already confirmed an open issue
-  // exists (signals.openIssues >= 1). This skips a redundant ~1.5s gh subprocess
-  // for active-by-artifact projects and when gh is unavailable (openIssues null).
+  // Only fetch the first issue/task when detection already confirmed an open
+  // one exists (signals.openIssues >= 1). This skips a redundant CLI subprocess
+  // for active-by-artifact projects and when the tracker is unavailable.
   let firstIssue = null;
-  if (state === 'active' && signals.openIssues >= 1) firstIssue = detectFirstOpenIssue();
+  if (state === 'active' && signals.openIssues >= 1) {
+    firstIssue = detectFirstOpenIssue({ activeTracker: signals.tracker });
+  }
   const message = renderGuidance(state, signals, firstIssue);
   if (!message) return ok();
   injectContext('SessionStart', '## Next step\n' + message);

--- a/install/install.js
+++ b/install/install.js
@@ -144,13 +144,18 @@ async function main() {
   if (workflowPack === 'enterprise') {
     console.log('  Issue tracker:\n');
     console.log('    1) Azure DevOps  (uses az devops CLI)');
-    console.log('    2) GitHub        (uses gh CLI)\n');
-    const trackerChoice = (await prompt('  Choice [1/2]: ', '2')).trim();
+    console.log('    2) GitHub        (uses gh CLI)');
+    console.log('    3) Todoist       (uses td CLI)\n');
+    const trackerChoice = (await prompt('  Choice [1/2/3]: ', '2')).trim();
     console.log('');
-    tracker = trackerChoice === '2' ? 'github' : 'ado';
+    tracker = trackerChoice === '1' ? 'ado' : trackerChoice === '3' ? 'todoist' : 'github';
   } else {
-    tracker = 'github';
-    console.log('  Tracker: GitHub (default for solo workflow)\n');
+    console.log('  Issue tracker:\n');
+    console.log('    1) GitHub   (uses gh CLI)');
+    console.log('    2) Todoist  (uses td CLI)\n');
+    const trackerChoice = (await prompt('  Choice [1/2]: ', '1')).trim();
+    console.log('');
+    tracker = trackerChoice === '2' ? 'todoist' : 'github';
   }
 
   // ── Preflight ──────────────────────────────────────────────────────────────
@@ -158,6 +163,7 @@ async function main() {
   let missing = 0;
   missing += checkTool('jq', 'https://jqlang.github.io/jq/download/');
   if (tracker === 'ado') missing += checkTool('az', 'https://aka.ms/installazurecli (then: az extension add --name azure-devops)');
+  else if (tracker === 'todoist') missing += checkTool('td', 'Todoist CLI — install from your package manager or see project README');
   else missing += checkTool('gh', 'https://cli.github.com');
   if (missing > 0) {
     console.error('\n  Error: Missing prerequisites above. Install them and re-run the installer.');

--- a/skills/grill-me/SKILL.md
+++ b/skills/grill-me/SKILL.md
@@ -120,7 +120,7 @@ If the user says continue, proceed to Step 7. If they want to revisit a branch, 
 
 ## Step 7 — Write grill-summary.md (MANDATORY)
 
-Always write a `grill-summary.md` file when shared understanding is reached. This artifact is consumed by downstream skills (`/research`, `/architect`, `/to-issues`) — without it, the decide phase has no handoff contract.
+Always write a `grill-summary.md` file when shared understanding is reached. This artifact is consumed by downstream skills (`/research`, `/architect`, `/to-issues`, `/to-todoist`) — without it, the decide phase has no handoff contract.
 
 Write to the repo root (or `tasks/stories/<id>/grill-summary.md` if a story context exists).
 
@@ -170,13 +170,14 @@ Structure:
 - `/research <topic>` — if external APIs or unfamiliar tech need investigation
 - `/architect` — to design the system architecture from this shared understanding
 - `/to-issues` — to break this directly into implementable GitHub issues
+- `/to-todoist` — to break this into Todoist tasks (if using Todoist as your tracker)
 ```
 
 After writing, say:
 
-> "Shared understanding written to `grill-summary.md`. Downstream skills (`/research`, `/architect`, `/to-issues`) will read this file as input.
+> "Shared understanding written to `grill-summary.md`. Downstream skills (`/research`, `/architect`, `/to-issues`, `/to-todoist`) will read this file as input.
 >
-> Suggested next step: [recommend based on what was discussed — research if tech is uncertain, architect if the system needs designing, or to-issues if it's straightforward enough to decompose now]"
+> Suggested next step: [recommend based on what was discussed — research if tech is uncertain, architect if the system needs designing, to-issues for GitHub Issues, or to-todoist for Todoist tasks if it's straightforward enough to decompose now]"
 
 ---
 

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: implement
-description: Build a feature from a GitHub issue or plain description — understand, plan, execute, evaluate, and PR in a streamlined flow. Lighter than /story — designed for solo devs and small teams. Usage: /implement <issue-id or description> [--discuss] [--research] [--quick] [--auto] [--full]
-argument-hint: "#42 or 'add dark mode to settings page'"
+description: Build a feature from a tracker task (GitHub issue, Todoist task) or plain description — understand, plan, execute, evaluate, and PR in a streamlined flow. Lighter than /story — designed for solo devs and small teams. Usage: /implement <issue-id, task-title, or description> [--discuss] [--research] [--quick] [--auto] [--full]
+argument-hint: "#42, 'Build login flow', or 'add dark mode to settings page'"
 ---
 
 **Core Philosophy:** Understand it, plan it, build it, check it, ship it — with a human gate at each step. Like `/story` but without the sprint ceremony.
@@ -37,13 +37,21 @@ Parse `$ARGUMENTS`:
 
 2. **Classify the remaining arguments:**
    - If they start with `#` or are a number → it's a **GitHub issue ID**
+   - If the active tracker is Todoist (check `tasks/tracker-config.md` for `**Type:** Todoist`):
+     - Quoted strings or task titles → it's a **Todoist task title** — search for it using `trackers/active/get-sprint-issues.sh` and match by title
+     - Numeric IDs without `#` → it's a **Todoist task ID** — fetch via `trackers/active/get-issue.sh <ID>`
    - Otherwise → it's a **plain text description**
 
-3. **Echo back** the parsed intent on one line, e.g. `Task: #42  |  Flags: --discuss --research`, so YOUR_NAME can catch a typo before anything else runs.
+3. **Echo back** the parsed intent on one line, e.g. `Task: #42  |  Flags: --discuss --research` or `Task: "Build login flow" (Todoist)  |  Flags: --research`, so YOUR_NAME can catch a typo before anything else runs.
+
+4. **Fetch task context** (if from a tracker):
+   - For GitHub issues: `bash trackers/active/get-issue.sh <NUMBER>`
+   - For Todoist tasks: `bash trackers/active/get-issue.sh <TASK_ID>`
+   - Use the fetched title, description, and acceptance criteria to enrich the planner's input.
 
 Create a branch for this work:
 ```bash
-git checkout -b implement/<issue-id-or-short-name>
+git checkout -b implement/<issue-id-or-slugified-title>
 ```
 
 ---

--- a/skills/to-todoist/SKILL.md
+++ b/skills/to-todoist/SKILL.md
@@ -8,7 +8,7 @@ triggers: /to-todoist
 
 Decompose planning artifacts into Todoist tasks. Each task is an independently demoable story. Stories are grouped under milestone parent tasks and created as subtasks.
 
-Uses the `td` CLI at `/opt/homebrew/bin/td` to create tasks in Todoist.
+Uses the `td` CLI (resolved from `$TODOIST_CLI` or `PATH`) to create tasks in Todoist. When the Todoist tracker adapter is installed (`trackers/active/` contains Todoist scripts), this skill also works through the adapter layer for standard operations.
 
 Reads from ALL available planning artifacts in the decide/define phases. No single artifact is required — uses whatever exists.
 
@@ -28,7 +28,7 @@ Reads from ALL available planning artifacts in the decide/define phases. No sing
 
 Before doing anything else:
 
-1. Check that `/opt/homebrew/bin/td` exists and is executable. If not, halt: *"Todoist CLI (td) not found at /opt/homebrew/bin/td. Install it first."*
+1. Check that `trackers/active/create-issue.sh` exists (Todoist adapter installed). Also verify the `td` CLI is available in PATH (or via `$TODOIST_CLI`). If neither is found, halt: *"Todoist tracker adapter not installed. Run the installer and select Todoist, or install the td CLI."*
 2. Scan for at least ONE planning artifact (see Phase 1). If none exist, halt: *"No planning artifacts found. Run `/grill-me` to establish shared understanding first, then optionally `/research` and `/architect`."*
 3. Resolve project and section:
    - If `--project` is provided, use it.
@@ -139,7 +139,7 @@ Do not proceed to Phase 5 without explicit user approval (unless `--dry-run`).
 ### 5a — Verify project exists
 
 ```bash
-/opt/homebrew/bin/td project list --json 2>/dev/null | grep -i "<project-name>"
+td project list --json 2>/dev/null | grep -i "<project-name>"
 ```
 
 If the project doesn't exist, inform the user and halt: *"Project '<name>' not found in Todoist. Create it first or provide a different project name."*
@@ -148,12 +148,12 @@ If the project doesn't exist, inform the user and halt: *"Project '<name>' not f
 
 Check if section exists:
 ```bash
-/opt/homebrew/bin/td section list "<project-name>" --json 2>/dev/null
+td section list "<project-name>" --json 2>/dev/null
 ```
 
 If the section doesn't exist, create it:
 ```bash
-/opt/homebrew/bin/td section create --project "<project-name>" --name "<section-name>"
+td section create --project "<project-name>" --name "<section-name>"
 ```
 
 ## Phase 6 — Create tasks in Todoist
@@ -163,7 +163,7 @@ If the section doesn't exist, create it:
 For each milestone, create an uncompletable parent task:
 
 ```bash
-/opt/homebrew/bin/td task add "<Milestone: name>" \
+td task add "<Milestone: name>" \
   --project "<project>" \
   --section "<section>" \
   --priority p1 \
@@ -179,7 +179,7 @@ Capture the returned task ID from the JSON output. Print the milestone name and 
 For each task within the milestone:
 
 ```bash
-/opt/homebrew/bin/td task add "<title>" \
+td task add "<title>" \
   --project "<project>" \
   --parent "id:<milestone-task-id>" \
   --priority <p1-p4> \
@@ -213,7 +213,7 @@ Print each created task (title + ID) as it's created. If creation fails, print t
 
 List tasks to confirm creation:
 ```bash
-/opt/homebrew/bin/td task list --project "<project>" --json
+td task list --project "<project>" --json
 ```
 
 ### 7b — Print summary

--- a/templates/tasks/flags-and-notes.md
+++ b/templates/tasks/flags-and-notes.md
@@ -24,6 +24,17 @@ _Anything Claude should know at the start of every session._
 
 ---
 
+## Todoist
+
+_Used by `/to-todoist` to set default project and section. Delete this section if not using Todoist._
+
+```
+project: YOUR_TODOIST_PROJECT
+section: YOUR_DEFAULT_SECTION
+```
+
+---
+
 ## Seeds
 
 _Forward-looking ideas that aren't ready yet. Each has a trigger condition — when the condition is met during work, surface the seed._

--- a/templates/tasks/tracker-config.md
+++ b/templates/tasks/tracker-config.md
@@ -8,13 +8,13 @@
 
 ## Issue Tracker
 
-**Type:** [ADO / GitHub]
+**Type:** [ADO / GitHub / Todoist]
 
-**Project/Board:** [YOUR_ADO_PROJECT or GitHub repo owner/name]
+**Project/Board:** [YOUR_ADO_PROJECT or GitHub repo owner/name or Todoist project name]
 
 **Sprint/Iteration naming:** [e.g. "Sprint 5"]
 
-### GitHub sprint settings *(GitHub only — delete if using ADO)*
+### GitHub sprint settings *(GitHub only — delete if using ADO or Todoist)*
 
 ```
 sprint_mode = milestone
@@ -29,6 +29,20 @@ github_project_number = 1
 
 Required when `sprint_mode = project`. This is the number from your project URL:
 `github.com/org/repo/projects/1` → set to `1`.
+
+### Todoist settings *(Todoist only — delete if using GitHub or ADO)*
+
+```
+todoist_project = My Project
+```
+
+The Todoist project name to list and create tasks in.
+
+```
+todoist_default_section = Sprint 1
+```
+
+Optional. The default section within the project. Sections map to sprints — `get-sprint-issues.sh` lists tasks in the named section.
 
 ---
 

--- a/trackers/README.md
+++ b/trackers/README.md
@@ -29,6 +29,7 @@ Skills and agents always call `trackers/active/<script>`. The installer copies t
 |---|---|---|
 | Azure DevOps | `trackers/ado/` | `az` + `az devops` extension |
 | GitHub | `trackers/github/` | `gh` |
+| Todoist | `trackers/todoist/` | `td` (or set `$TODOIST_CLI`) |
 
 ---
 
@@ -116,6 +117,45 @@ GitHub has no native parent/child issue relationship. `get-issue-children.sh` re
 
 ---
 
+## Todoist adapter notes
+
+Requires:
+- `td` CLI (Todoist command-line client)
+- Authenticated with a valid API token
+
+### Concept mapping
+
+Todoist doesn't have native equivalents for all GitHub/ADO concepts. The adapter maps them:
+
+| Tracker concept | Todoist equivalent |
+|---|---|
+| Issue / Work item | Task |
+| Sub-issue | Sub-task (`--parent`) |
+| Sprint / Iteration | Section within a project |
+| Label | Label |
+| Milestone | Uncompletable parent task |
+| PR review threads | N/A (no-op stubs — returns empty) |
+
+### Sprint / section mapping
+
+`get-sprint-issues.sh` lists tasks in a named Todoist section. Configure the project in `tasks/tracker-config.md`:
+
+```
+todoist_project = My Project
+```
+
+Call with a section name to filter: `get-sprint-issues.sh "Sprint 1"`. Without arguments, lists all open tasks in the configured project.
+
+### CLI resolution
+
+The adapter resolves the `td` binary from:
+1. `$TODOIST_CLI` environment variable (if set)
+2. `td` on `$PATH`
+
+This makes the adapter portable across macOS (Homebrew) and Linux installs without hardcoding a path.
+
+---
+
 ## Switching trackers after install
 
 Re-run the installer and choose a different tracker:
@@ -127,6 +167,10 @@ Or manually copy an adapter:
 ```bash
 # Switch to GitHub
 cp trackers/github/*.sh ~/.claude/trackers/active/
+chmod +x ~/.claude/trackers/active/*.sh
+
+# Switch to Todoist
+cp trackers/todoist/*.sh ~/.claude/trackers/active/
 chmod +x ~/.claude/trackers/active/*.sh
 ```
 

--- a/trackers/__tests__/conformance.test.js
+++ b/trackers/__tests__/conformance.test.js
@@ -76,6 +76,7 @@ function runScript(adapter, script, args, { fixtureMode, fixtureAuth, retryCount
       RETRY_BACKOFF_1: '0',
       RETRY_BACKOFF_2: '0',
     };
+    if (adapter === 'todoist') env.TODOIST_CLI = path.join(FIXTURES_BIN, 'td');
     if (fixtureMode) env.FIXTURE_MODE = fixtureMode;
     if (fixtureAuth) env.FIXTURE_AUTH = fixtureAuth;
     if (retryCounter) {
@@ -106,7 +107,7 @@ function normalize(s) {
 // ── Argument validation contract ──────────────────────────────────────
 
 describe('arg-validation', () => {
-  for (const adapter of ['ado', 'github']) {
+  for (const adapter of ['ado', 'github', 'todoist']) {
     test(`${adapter}_GetIssue_NoArg_Exits1WithJsonError`, () => {
       const r = runScript(adapter, 'get-issue.sh', []);
       assert.equal(r.exitCode, 1);
@@ -139,6 +140,20 @@ describe('happy-path-stdout', () => {
     const r = runScript('github', 'get-issue.sh', ['1234']);
     assert.equal(r.exitCode, 0, `non-zero exit: ${r.stderr}`);
     assert.equal(normalize(r.stdout), normalize(readGolden('github', 'get-issue.happy.md')));
+  });
+
+  test('todoist_GetIssue_HappyPath_MatchesGoldenMarkdown', () => {
+    const r = runScript('todoist', 'get-issue.sh', ['1234']);
+    assert.equal(r.exitCode, 0, `non-zero exit: ${r.stderr}`);
+    assert.equal(normalize(r.stdout), normalize(readGolden('todoist', 'get-issue.happy.md')));
+  });
+
+  test('todoist_GetPrReviewThreads_HappyPath_ReturnsEmptyArray', () => {
+    const r = runScript('todoist', 'get-pr-review-threads.sh', ['42']);
+    assert.equal(r.exitCode, 0, `non-zero exit: ${r.stderr}`);
+    const parsed = JSON.parse(r.stdout);
+    assert.ok(Array.isArray(parsed), 'expected JSON array');
+    assert.equal(parsed.length, 0, 'Todoist PR threads stub must return empty array');
   });
 
   test('github_GetPrReviewThreads_HappyPath_ReturnsJsonArrayWithRequiredKeys', () => {
@@ -183,6 +198,18 @@ describe('failure-modes', () => {
     assert.equal(r.exitCode, 1);
     assert.match(r.stderr, /gh auth|expired/i);
   });
+
+  test('todoist_GetIssue_NotFound_Exits1WithJsonStderr', () => {
+    const r = runScript('todoist', 'get-issue.sh', ['9999']);
+    assert.equal(r.exitCode, 1);
+    assert.match(r.stderr, /\{"error":/);
+  });
+
+  test('todoist_GetIssue_AuthExpired_Exits1WithAuthError', () => {
+    const r = runScript('todoist', 'get-issue.sh', ['1234'], { fixtureAuth: 'expired' });
+    assert.equal(r.exitCode, 1);
+    assert.match(r.stderr, /auth/i);
+  });
 });
 
 // ── Retry behaviour ──────────────────────────────────────────────────
@@ -221,12 +248,27 @@ describe('retry', () => {
       try { fs.unlinkSync(counter); } catch { /* ignore */ }
     }
   });
+
+  test('todoist_GetIssue_TransientFailure_RetriesAndSucceeds', () => {
+    const counter = path.join(os.tmpdir(), `retry-counter-${process.pid}-${Date.now()}`);
+    try {
+      const r = runScript('todoist', 'get-issue.sh', ['1234'], {
+        retryCounter: counter,
+        retrySucceedAt: 2,
+      });
+      assert.equal(r.exitCode, 0, `expected success after retry: ${r.stderr}`);
+      const count = parseInt(fs.readFileSync(counter, 'utf8'), 10);
+      assert.ok(count >= 2);
+    } finally {
+      try { fs.unlinkSync(counter); } catch { /* ignore */ }
+    }
+  });
 });
 
 // ── Tracker README + lib presence ────────────────────────────────────
 
 describe('contract-presence', () => {
-  for (const adapter of ['ado', 'github']) {
+  for (const adapter of ['ado', 'github', 'todoist']) {
     test(`${adapter}_HasAllSixContractScripts`, () => {
       const required = [
         'get-issue.sh',

--- a/trackers/__tests__/fixtures/bin/td
+++ b/trackers/__tests__/fixtures/bin/td
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Stub `td` for tracker conformance tests. Pattern-matches argv against
+# known adapter call signatures and returns canned JSON.
+
+set -e
+
+fixture_dir="$(dirname "$0")/../responses"
+
+# Auth check — project list is used by check_auth_todoist.
+if [ "$1" = "project" ] && [ "$2" = "list" ]; then
+  if [ "$FIXTURE_AUTH" = "expired" ]; then
+    echo "Error: authentication failed" >&2
+    exit 1
+  fi
+  echo '[{"id": "111", "name": "TestProject"}]'
+  exit 0
+fi
+
+# Retry-mode fixture.
+if [ -n "$FIXTURE_RETRY_COUNTER" ]; then
+  count=0
+  if [ -f "$FIXTURE_RETRY_COUNTER" ]; then
+    count=$(cat "$FIXTURE_RETRY_COUNTER")
+  fi
+  count=$((count + 1))
+  echo "$count" > "$FIXTURE_RETRY_COUNTER"
+  if [ "$count" -lt "${FIXTURE_RETRY_SUCCEED_AT:-2}" ]; then
+    echo '{"error": "transient 503"}' >&2
+    exit 1
+  fi
+fi
+
+# Failure modes.
+case "$FIXTURE_MODE" in
+  not-found)
+    echo '{"error": "Task not found"}' >&2
+    exit 1
+    ;;
+  auth-failed)
+    echo '{"error": "401 Unauthorized"}' >&2
+    exit 1
+    ;;
+  malformed)
+    echo 'not json at all'
+    exit 0
+    ;;
+esac
+
+# Task dispatch.
+case "$1 $2" in
+  "task view")
+    if [ "$3" = "9999" ]; then
+      echo '{"error": "task 9999 not found"}' >&2
+      exit 1
+    fi
+    cat "$fixture_dir/td-task-1234.json"
+    exit 0
+    ;;
+  "task list")
+    cat "$fixture_dir/td-task-list.json"
+    exit 0
+    ;;
+  "task add")
+    echo '{"id": "9876543", "content": "New task", "url": "https://todoist.com/showTask?id=9876543"}'
+    exit 0
+    ;;
+  "task update")
+    echo '{"id": "1234", "content": "Updated task"}'
+    exit 0
+    ;;
+esac
+
+echo "{\"error\": \"stub td: no fixture for: $*\"}" >&2
+exit 1

--- a/trackers/__tests__/fixtures/responses/td-task-1234.json
+++ b/trackers/__tests__/fixtures/responses/td-task-1234.json
@@ -1,0 +1,12 @@
+{
+  "id": "1234",
+  "content": "Implement login flow",
+  "description": "Users need to be able to log in.\n\n## Acceptance criteria\n- Valid credentials authenticate the user\n",
+  "labels": ["feature", "priority-high"],
+  "priority": 3,
+  "is_completed": false,
+  "section_id": "555",
+  "project_id": "111",
+  "parent_id": null,
+  "url": "https://todoist.com/showTask?id=1234"
+}

--- a/trackers/__tests__/fixtures/responses/td-task-list.json
+++ b/trackers/__tests__/fixtures/responses/td-task-list.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": "1234",
+    "content": "Implement login flow",
+    "description": "Users need to be able to log in.",
+    "labels": ["feature", "priority-high"],
+    "priority": 3,
+    "is_completed": false,
+    "section_id": "555",
+    "project_id": "111"
+  },
+  {
+    "id": "1235",
+    "content": "Add password reset",
+    "description": "Users should be able to reset their password.",
+    "labels": ["feature"],
+    "priority": 2,
+    "is_completed": false,
+    "section_id": "555",
+    "project_id": "111"
+  }
+]

--- a/trackers/__tests__/golden/todoist/get-issue.happy.md
+++ b/trackers/__tests__/golden/todoist/get-issue.happy.md
@@ -1,0 +1,13 @@
+# Task 1234: Implement login flow
+
+**State:** OPEN
+**Priority:** p2
+**Labels:** feature, priority-high
+**Section:** 555
+**Project:** 111
+
+## Description
+Users need to be able to log in.
+
+## Acceptance criteria
+- Valid credentials authenticate the user

--- a/trackers/lib/auth-check.sh
+++ b/trackers/lib/auth-check.sh
@@ -68,3 +68,22 @@ check_auth_github() {
     exit 1
   fi
 }
+
+check_auth_todoist() {
+  local td="${TODOIST_CLI:-td}"
+
+  if ! command -v "$td" &>/dev/null; then
+    echo '{"error": "Todoist CLI (td) not found. Install it or set TODOIST_CLI."}' >&2
+    exit 1
+  fi
+
+  # Verify td CLI can reach the API with a lightweight call
+  local check_output
+  check_output=$("$td" project list --json 2>&1)
+  local exit_code=$?
+
+  if [ $exit_code -ne 0 ]; then
+    echo '{"error": "Todoist CLI auth failed. Check your API token configuration."}' >&2
+    exit 1
+  fi
+}

--- a/trackers/todoist/add-label.sh
+++ b/trackers/todoist/add-label.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# add-label.sh — Todoist adapter
+# Usage: bash .claude/trackers/active/add-label.sh <TASK_ID> "<label>"
+# Adds a label to the specified task.
+
+set -o pipefail
+
+TASK_ID="${1:-}"
+LABEL="${2:-}"
+
+if [ -z "$TASK_ID" ] || [ -z "$LABEL" ]; then
+  echo '{"error": "Usage: add-label.sh <TASK_ID> \"<label>\""}' >&2
+  exit 1
+fi
+
+TD="${TODOIST_CLI:-td}"
+
+if ! command -v "$TD" &>/dev/null; then
+  echo '{"error": "Todoist CLI (td) not found. Install it or set TODOIST_CLI."}' >&2
+  exit 1
+fi
+
+source "$(dirname "$0")/../lib/retry.sh"
+source "$(dirname "$0")/../lib/auth-check.sh"
+check_auth_todoist
+
+with_retry "$TD" task update "$TASK_ID" --add-label "$LABEL"

--- a/trackers/todoist/create-issue.sh
+++ b/trackers/todoist/create-issue.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# create-issue.sh — Todoist adapter
+# Usage: bash .claude/trackers/active/create-issue.sh "<title>" "<body>" "<label>" ["<section>"] ["<project>"]
+# Returns the created task URL.
+# label, section, and project are optional.
+
+set -o pipefail
+
+TITLE="${1:-}"
+BODY="${2:-}"
+LABEL="${3:-}"
+SECTION="${4:-}"
+PROJECT="${5:-}"
+
+if [ -z "$TITLE" ]; then
+  echo '{"error": "Title required. Usage: create-issue.sh \"<title>\" \"<body>\" [\"<label>\"] [\"<section>\"] [\"<project>\"]"}' >&2
+  exit 1
+fi
+
+TD="${TODOIST_CLI:-td}"
+
+if ! command -v "$TD" &>/dev/null; then
+  echo '{"error": "Todoist CLI (td) not found. Install it or set TODOIST_CLI."}' >&2
+  exit 1
+fi
+
+source "$(dirname "$0")/../lib/retry.sh"
+source "$(dirname "$0")/../lib/auth-check.sh"
+check_auth_todoist
+
+CREATE_ARGS=(task add "$TITLE")
+
+if [ -n "$BODY" ]; then
+  CREATE_ARGS+=(--description "$BODY")
+fi
+
+if [ -n "$LABEL" ]; then
+  CREATE_ARGS+=(--label "$LABEL")
+fi
+
+if [ -n "$SECTION" ]; then
+  CREATE_ARGS+=(--section "$SECTION")
+fi
+
+if [ -n "$PROJECT" ]; then
+  CREATE_ARGS+=(--project "$PROJECT")
+fi
+
+CREATE_ARGS+=(--json)
+
+RESULT=$(with_retry "$TD" "${CREATE_ARGS[@]}")
+
+if [ -z "$RESULT" ]; then
+  echo '{"error": "Failed to create task"}' >&2
+  exit 1
+fi
+
+TASK_URL=$(echo "$RESULT" | jq -r '.url // empty')
+TASK_ID=$(echo "$RESULT" | jq -r '.id // empty')
+
+if [ -n "$TASK_URL" ]; then
+  echo "$TASK_URL"
+elif [ -n "$TASK_ID" ]; then
+  echo "https://todoist.com/showTask?id=$TASK_ID"
+else
+  echo "$RESULT"
+fi

--- a/trackers/todoist/get-issue-children.sh
+++ b/trackers/todoist/get-issue-children.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# get-issue-children.sh — Todoist adapter
+# Usage: bash .claude/trackers/active/get-issue-children.sh <TASK_ID>
+# Lists sub-tasks of the given parent task.
+# Output: markdown-formatted list of children.
+
+set -o pipefail
+
+TASK_ID=$1
+
+if [ -z "$TASK_ID" ]; then
+  echo '{"error": "Task ID required. Usage: get-issue-children.sh <TASK_ID>"}' >&2
+  exit 1
+fi
+
+TD="${TODOIST_CLI:-td}"
+
+if ! command -v "$TD" &>/dev/null; then
+  echo '{"error": "Todoist CLI (td) not found. Install it or set TODOIST_CLI."}' >&2
+  exit 1
+fi
+
+source "$(dirname "$0")/../lib/retry.sh"
+source "$(dirname "$0")/../lib/auth-check.sh"
+check_auth_todoist
+
+CHILDREN=$(with_retry "$TD" task list --parent "$TASK_ID" --json)
+
+TOTAL=$(echo "$CHILDREN" | jq 'length' 2>/dev/null)
+
+if [ "$TOTAL" -gt 0 ] 2>/dev/null; then
+  echo "# Sub-tasks for Task $TASK_ID"
+  echo ""
+  echo "$CHILDREN" | jq -r '.[] |
+    "- [" + (if .is_completed then "x" else " " end) + "] " + (.id|tostring) + " " + .content + " (" + (if .is_completed then "CLOSED" else "OPEN" end) + ")"'
+  echo ""
+  OPEN=$(echo "$CHILDREN" | jq '[.[] | select(.is_completed == false)] | length')
+  CLOSED=$(echo "$CHILDREN" | jq '[.[] | select(.is_completed == true)] | length')
+  echo "_Progress: $CLOSED/$TOTAL complete ($OPEN open)_"
+else
+  echo "# Sub-tasks for Task $TASK_ID"
+  echo ""
+  echo "_No sub-tasks found._"
+fi

--- a/trackers/todoist/get-issue.sh
+++ b/trackers/todoist/get-issue.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# get-issue.sh — Todoist adapter
+# Usage: bash .claude/trackers/active/get-issue.sh <TASK_ID>
+# Returns full details of a single task: title, description, labels, priority, state.
+
+set -o pipefail
+
+TASK_ID=$1
+
+if [ -z "$TASK_ID" ]; then
+  echo '{"error": "Task ID required. Usage: get-issue.sh <TASK_ID>"}' >&2
+  exit 1
+fi
+
+TD="${TODOIST_CLI:-td}"
+
+if ! command -v "$TD" &>/dev/null; then
+  echo '{"error": "Todoist CLI (td) not found. Install it or set TODOIST_CLI."}' >&2
+  exit 1
+fi
+
+source "$(dirname "$0")/../lib/retry.sh"
+source "$(dirname "$0")/../lib/auth-check.sh"
+check_auth_todoist
+
+RAW=$(with_retry "$TD" task view "$TASK_ID" --json)
+
+if [ -z "$RAW" ]; then
+  echo '{"error": "Task not found or empty response"}' >&2
+  exit 1
+fi
+
+echo "$RAW" | jq -r '
+  "# Task " + (.id|tostring) + ": " + .content,
+  "",
+  "**State:** " + (if .is_completed then "CLOSED" else "OPEN" end),
+  "**Priority:** " + (if .priority == 4 then "p1" elif .priority == 3 then "p2" elif .priority == 2 then "p3" else "p4" end),
+  "**Labels:** " + (if (.labels | length) > 0 then (.labels | join(", ")) else "None" end),
+  "**Section:** " + (.section_id // "None" | tostring),
+  "**Project:** " + (.project_id // "None" | tostring),
+  "",
+  "## Description",
+  (.description // "_No description_")
+'

--- a/trackers/todoist/get-pr-review-threads.sh
+++ b/trackers/todoist/get-pr-review-threads.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# get-pr-review-threads.sh — Todoist adapter (no-op)
+# Todoist has no pull request concept. Returns an empty JSON array.
+# Usage: bash .claude/trackers/active/get-pr-review-threads.sh <PR_NUMBER>
+
+PR=$1
+
+if [ -z "$PR" ]; then
+  echo '{"error": "PR number required. Usage: get-pr-review-threads.sh <PR_NUMBER>"}' >&2
+  exit 1
+fi
+
+source "$(dirname "$0")/../lib/retry.sh"
+source "$(dirname "$0")/../lib/auth-check.sh"
+
+echo '[]'

--- a/trackers/todoist/get-sprint-issues.sh
+++ b/trackers/todoist/get-sprint-issues.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# get-sprint-issues.sh — Todoist adapter
+# Usage: bash .claude/trackers/active/get-sprint-issues.sh <SECTION_OR_PROJECT>
+#
+# Todoist maps sprints to sections within a project. The argument is either:
+#   - A section name (matched case-insensitively)
+#   - Empty (lists all open tasks in the configured project)
+#
+# Config is read from tasks/tracker-config.md:
+#   todoist_project = <project-name>
+
+SECTION=$1
+
+TD="${TODOIST_CLI:-td}"
+
+if ! command -v "$TD" &>/dev/null; then
+  echo '{"error": "Todoist CLI (td) not found. Install it or set TODOIST_CLI."}' >&2
+  exit 1
+fi
+
+source "$(dirname "$0")/../lib/retry.sh"
+source "$(dirname "$0")/../lib/auth-check.sh"
+check_auth_todoist
+
+TODOIST_PROJECT=""
+
+if [ -f "tasks/tracker-config.md" ]; then
+  _proj=$(grep -i "todoist_project\s*=" tasks/tracker-config.md | sed 's/.*=\s*//' | tr -d ' \r\n')
+  [ -n "$_proj" ] && TODOIST_PROJECT="$_proj"
+fi
+
+LIST_ARGS=(task list --json)
+
+if [ -n "$TODOIST_PROJECT" ]; then
+  LIST_ARGS+=(--project "$TODOIST_PROJECT")
+fi
+
+if [ -n "$SECTION" ]; then
+  LIST_ARGS+=(--section "$SECTION")
+fi
+
+with_retry "$TD" "${LIST_ARGS[@]}"

--- a/trackers/todoist/remove-label.sh
+++ b/trackers/todoist/remove-label.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# remove-label.sh — Todoist adapter
+# Usage: bash .claude/trackers/active/remove-label.sh <TASK_ID> "<label>"
+# Removes a label from the specified task.
+
+set -o pipefail
+
+TASK_ID="${1:-}"
+LABEL="${2:-}"
+
+if [ -z "$TASK_ID" ] || [ -z "$LABEL" ]; then
+  echo '{"error": "Usage: remove-label.sh <TASK_ID> \"<label>\""}' >&2
+  exit 1
+fi
+
+TD="${TODOIST_CLI:-td}"
+
+if ! command -v "$TD" &>/dev/null; then
+  echo '{"error": "Todoist CLI (td) not found. Install it or set TODOIST_CLI."}' >&2
+  exit 1
+fi
+
+source "$(dirname "$0")/../lib/retry.sh"
+source "$(dirname "$0")/../lib/auth-check.sh"
+check_auth_todoist
+
+with_retry "$TD" task update "$TASK_ID" --remove-label "$LABEL"

--- a/trackers/todoist/reply-pr-thread.sh
+++ b/trackers/todoist/reply-pr-thread.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# reply-pr-thread.sh — Todoist adapter (no-op)
+# Todoist has no pull request concept. Exits silently.
+# Usage: bash .claude/trackers/active/reply-pr-thread.sh <PR_NUMBER> <THREAD_ID> "Reply text"
+
+PR=$1
+THREAD_ID=$2
+REPLY_TEXT=$3
+
+if [ -z "$PR" ] || [ -z "$THREAD_ID" ] || [ -z "$REPLY_TEXT" ]; then
+  echo '{"error": "All 3 args required. Usage: reply-pr-thread.sh <PR_NUMBER> <THREAD_ID> <REPLY_TEXT>"}' >&2
+  exit 1
+fi
+
+source "$(dirname "$0")/../lib/retry.sh"
+source "$(dirname "$0")/../lib/auth-check.sh"
+
+exit 0

--- a/trackers/todoist/resolve-pr-thread.sh
+++ b/trackers/todoist/resolve-pr-thread.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# resolve-pr-thread.sh — Todoist adapter (no-op)
+# Todoist has no pull request concept. Exits silently.
+# Usage: bash .claude/trackers/active/resolve-pr-thread.sh <PR_NUMBER> <THREAD_NODE_ID>
+
+PR=$1
+THREAD_NODE_ID=$2
+
+if [ -z "$PR" ] || [ -z "$THREAD_NODE_ID" ]; then
+  echo '{"error": "Both args required. Usage: resolve-pr-thread.sh <PR_NUMBER> <THREAD_NODE_ID>"}' >&2
+  exit 1
+fi
+
+source "$(dirname "$0")/../lib/retry.sh"
+source "$(dirname "$0")/../lib/auth-check.sh"
+
+exit 0


### PR DESCRIPTION
## Summary

- **Todoist tracker adapter** — 9 scripts in `trackers/todoist/` implementing the full adapter interface (get-issue, get-issue-children, get-sprint-issues, create-issue, add/remove-label, plus PR no-op stubs). CLI resolved from `$TODOIST_CLI` or `$PATH`.
- **Tracker-agnostic session routing** — `project-state.js` now detects which tracker is active and probes for open tasks accordingly. Projects using Todoist get `/implement "task title"` guidance instead of `/implement #42`.
- **Downstream skill updates** — `/implement` accepts Todoist task titles/IDs, `/grill-me` recommends `/to-todoist` as a downstream skill, `/to-todoist` itself no longer hardcodes `/opt/homebrew/bin/td`.
- **Installer support** — Both solo and enterprise packs offer Todoist as a tracker choice with `td` CLI preflight check.
- **Documentation** — Updated trackers README (concept mapping, CLI resolution), project README, CHANGELOG, tracker-config template, and flags-and-notes template.

**Root cause:** `/to-todoist` was a write-only standalone skill that bypassed the tracker adapter layer. When starting a new session after creating Todoist tasks, the session router called `gh issue list`, found nothing, and routed to GitHub Issues instead.

**27 files changed, 898 insertions, 55 deletions. 35/35 hook tests pass (11 new), 8/8 new conformance tests pass.**

## Test plan

- [ ] Run `node --test hooks/__tests__/project-state.test.js` — 25 tests including 11 Todoist-specific
- [ ] Run `node --test hooks/__tests__/session-router.test.js` — 10 tests including tracker-agnostic guidance
- [ ] Run `node --test trackers/__tests__/conformance.test.js` — Todoist arg-validation, happy-path, failure-modes, retry, contract-presence
- [ ] Install with Todoist selected, verify `trackers/active/` gets Todoist scripts
- [ ] Create tasks with `/to-todoist`, start new session, verify session-router detects Todoist tasks
- [ ] Run `/implement "task title"` with Todoist tracker active

🤖 Generated with [Claude Code](https://claude.com/claude-code)