### PR TITLE
chore: repo quality fixes and gitignore cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ tasks/stories/
 # Auto-generated catalog (produced by catalog-skills.js)
 SKILLS_CATALOG.md
 
+# Chief Operator state (overwritten every session)
+operator-state.md
+
 # Transient skill handoff (overwritten each /grill-me session)
 grill-summary.md
 


### PR DESCRIPTION
## Summary

- **CI fix**: switch `npm ci` to `npm install` (no lockfile is committed, so `ci` fails)
- **Gitignore cleanup**: ignore `grill-summary.md` (transient skill output) and `operator-state.md` (chief-operator rewrites this every session)
- **Installer refactor**: decompose `install.js` into `lib/copy.js`, `lib/substitution.js`, `lib/updater.js` for maintainability
- **Type safety**: add `@ts-check` and JSDoc annotations to hook scripts, enabling `tsc --noEmit` type checking without a compile step

## Test plan

- [x] CI passes (lint, typecheck, test with coverage)
- [x] Existing tests unaffected by installer decomposition
- [x] `operator-state.md` and `grill-summary.md` excluded from tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)