### PR TITLE
feat: local tracker backend (WS2)

### DIFF
--- a/examples/settings.json
+++ b/examples/settings.json
@@ -26,6 +26,10 @@
           {
             "type": "command",
             "command": "node \"/home/username/.claude/hooks/drift-check.js\""
+          },
+          {
+            "type": "command",
+            "command": "node \"/home/username/.claude/hooks/todo-render-trigger.js\""
           }
         ]
       }

--- a/hooks/__tests__/todo-render-trigger.test.js
+++ b/hooks/__tests__/todo-render-trigger.test.js
@@ -1,0 +1,87 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const HOOK = path.join(__dirname, '..', 'todo-render-trigger.js');
+
+function makeFixture({ tracker = 'local' } = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'todo-render-'));
+  const claudeDir = path.join(dir, '.claude');
+  fs.mkdirSync(claudeDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(claudeDir, '.harness-manifest.json'),
+    JSON.stringify({ tracker })
+  );
+  return { root: dir };
+}
+
+function cleanup(root) {
+  try { fs.rmSync(root, { recursive: true, force: true }); } catch { /* ignore */ }
+}
+
+function runHook(filePath, { cwd } = {}) {
+  const result = spawnSync(
+    process.execPath,
+    [HOOK],
+    {
+      input: JSON.stringify({ tool_input: { file_path: filePath } }),
+      encoding: 'utf8',
+      cwd: cwd || process.cwd(),
+      env: { ...process.env },
+      timeout: 10000,
+    }
+  );
+  return { stdout: result.stdout, stderr: result.stderr, exitCode: result.status };
+}
+
+test('exits 0 silently for unrelated file path', () => {
+  const { root } = makeFixture();
+  try {
+    const result = runHook('/some/project/src/index.ts', { cwd: root });
+    assert.equal(result.exitCode, 0);
+  } finally { cleanup(root); }
+});
+
+test('exits 0 silently when file is under tasks/issues/ but mode is not local', () => {
+  const { root } = makeFixture({ tracker: 'github' });
+  try {
+    const result = runHook(path.join(root, 'tasks/issues/42.md'), { cwd: root });
+    assert.equal(result.exitCode, 0);
+  } finally { cleanup(root); }
+});
+
+test('exits 0 when file is under tasks/issues/ and mode is local', () => {
+  const { root } = makeFixture({ tracker: 'local' });
+  try {
+    const result = runHook(path.join(root, 'tasks/issues/42.md'), { cwd: root });
+    assert.equal(result.exitCode, 0);
+  } finally { cleanup(root); }
+});
+
+test('exits 0 when no manifest exists (fail-open)', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'todo-render-nomanifest-'));
+  try {
+    const result = runHook(path.join(dir, 'tasks/issues/42.md'), { cwd: dir });
+    assert.equal(result.exitCode, 0);
+  } finally { cleanup(dir); }
+});
+
+test('exits 0 when no file_path in input', () => {
+  const { root } = makeFixture();
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [HOOK],
+      {
+        input: JSON.stringify({ tool_input: {} }),
+        encoding: 'utf8',
+        cwd: root,
+        timeout: 10000,
+      }
+    );
+    assert.equal(result.status, 0);
+  } finally { cleanup(root); }
+});

--- a/hooks/todo-render-trigger.js
+++ b/hooks/todo-render-trigger.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+// @ts-check
+// PostToolUse hook — re-render tasks/todo.md when a file under tasks/issues/
+// is edited directly. Only active in local tracker mode (reads manifest).
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+const { readStdinJson, ok, runHook } = require('./lib/hook-io');
+
+runHook('todo-render-trigger', async () => {
+  const input = await readStdinJson();
+  const filePath = (input.tool_input && input.tool_input.file_path) || '';
+  if (!filePath) return ok();
+
+  const normalized = filePath.replace(/\\/g, '/');
+  if (!/\/tasks\/issues\//.test(normalized)) return ok();
+
+  // Check manifest — only fire in local mode
+  const manifestPath = path.join(process.cwd(), '.claude', '.harness-manifest.json');
+  try {
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    if (manifest.tracker !== 'local') return ok();
+  } catch {
+    // No manifest or unreadable — assume not local mode
+    return ok();
+  }
+
+  // Fire render-todo.sh (fire and forget)
+  const renderScript = path.join(__dirname, '..', 'trackers', 'lib', 'render-todo.sh');
+  if (!fs.existsSync(renderScript)) {
+    process.stderr.write(`todo-render-trigger.js: render-todo.sh not found at '${renderScript}'\n`);
+    return ok();
+  }
+
+  const child = spawn('bash', [renderScript, 'tasks/issues'], {
+    detached: true,
+    stdio: 'ignore',
+  });
+  child.unref();
+
+  ok();
+});

--- a/trackers/__tests__/conformance.test.js
+++ b/trackers/__tests__/conformance.test.js
@@ -24,6 +24,7 @@ const { spawnSync } = require('node:child_process');
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
 const ADAPTERS_DIR = path.join(REPO_ROOT, 'trackers');
 const FIXTURES_BIN = path.join(__dirname, 'fixtures', 'bin');
+const FIXTURES_LOCAL_ISSUES = path.join(__dirname, 'fixtures', 'local-issues');
 const GOLDEN_DIR = path.join(__dirname, 'golden');
 
 const HAS_BASH = (() => {
@@ -99,6 +100,77 @@ function runScript(adapter, script, args, { fixtureMode, fixtureAuth, retryCount
   } finally { cleanup(root); }
 }
 
+// Local backend uses a temp tasks/issues/ dir instead of PATH-override mocks.
+function prepareLocalAdapter() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'tracker-local-'));
+  const adapterDir = path.join(tmp, 'local');
+  fs.cpSync(path.join(ADAPTERS_DIR, 'local'), adapterDir, { recursive: true });
+  fs.cpSync(path.join(ADAPTERS_DIR, 'lib'), path.join(tmp, 'lib'), { recursive: true });
+
+  // Seed fixture tasks/issues/ directory
+  const issuesDir = path.join(tmp, 'tasks', 'issues');
+  fs.mkdirSync(issuesDir, { recursive: true });
+  fs.cpSync(FIXTURES_LOCAL_ISSUES, issuesDir, { recursive: true });
+
+  // Create tasks/ dir for todo.md output
+  fs.mkdirSync(path.join(tmp, 'tasks'), { recursive: true });
+
+  return { root: tmp, adapterDir, issuesDir };
+}
+
+function runLocalScript(script, args, { issuesDir } = {}) {
+  const { root, adapterDir, issuesDir: defaultIssuesDir } = prepareLocalAdapter();
+  const effectiveIssuesDir = issuesDir || defaultIssuesDir;
+  try {
+    const env = {
+      ...process.env,
+      LOCAL_ISSUES_DIR: effectiveIssuesDir,
+      TODO_OUTPUT: path.join(root, 'tasks', 'todo.md'),
+      RETRY_BACKOFF_1: '0',
+      RETRY_BACKOFF_2: '0',
+    };
+    const result = spawnSync('bash', [path.join(adapterDir, script), ...args], {
+      encoding: 'utf8',
+      env,
+      cwd: root,
+      timeout: 15000,
+    });
+    return {
+      exitCode: result.status,
+      stdout: result.stdout || '',
+      stderr: result.stderr || '',
+      root,
+      issuesDir: effectiveIssuesDir,
+    };
+  } finally { cleanup(root); }
+}
+
+// Like runLocalScript but returns root for inspection before cleanup
+function runLocalScriptKeep(script, args) {
+  const { root, adapterDir, issuesDir } = prepareLocalAdapter();
+  const env = {
+    ...process.env,
+    LOCAL_ISSUES_DIR: issuesDir,
+    TODO_OUTPUT: path.join(root, 'tasks', 'todo.md'),
+    RETRY_BACKOFF_1: '0',
+    RETRY_BACKOFF_2: '0',
+  };
+  const result = spawnSync('bash', [path.join(adapterDir, script), ...args], {
+    encoding: 'utf8',
+    env,
+    cwd: root,
+    timeout: 15000,
+  });
+  return {
+    exitCode: result.status,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+    root,
+    issuesDir,
+    adapterDir,
+  };
+}
+
 function readGolden(adapter, name) {
   return fs.readFileSync(path.join(GOLDEN_DIR, adapter, name), 'utf8');
 }
@@ -123,6 +195,48 @@ describe('arg-validation', () => {
       assert.match(r.stderr, /\{"error":/);
     });
   }
+
+  test('local_GetIssue_NoArg_Exits1WithJsonError', () => {
+    const r = runLocalScript('get-issue.sh', []);
+    assert.equal(r.exitCode, 1);
+    assert.match(r.stderr, /\{"error":/);
+  });
+
+  test('local_CloseIssue_NoArg_Exits1WithJsonError', () => {
+    const r = runLocalScript('close-issue.sh', []);
+    assert.equal(r.exitCode, 1);
+    assert.match(r.stderr, /\{"error":/);
+  });
+
+  test('local_CreateIssue_NoArg_Exits1WithJsonError', () => {
+    const r = runLocalScript('create-issue.sh', []);
+    assert.equal(r.exitCode, 1);
+    assert.match(r.stderr, /\{"error":/);
+  });
+
+  test('local_AddLabel_NoArgs_Exits1WithJsonError', () => {
+    const r = runLocalScript('add-label.sh', []);
+    assert.equal(r.exitCode, 1);
+    assert.match(r.stderr, /\{"error":/);
+  });
+
+  test('local_RemoveLabel_NoArgs_Exits1WithJsonError', () => {
+    const r = runLocalScript('remove-label.sh', []);
+    assert.equal(r.exitCode, 1);
+    assert.match(r.stderr, /\{"error":/);
+  });
+
+  test('local_GetIssueChildren_NoArg_Exits1WithJsonError', () => {
+    const r = runLocalScript('get-issue-children.sh', []);
+    assert.equal(r.exitCode, 1);
+    assert.match(r.stderr, /\{"error":/);
+  });
+
+  test('local_GetSprintIssues_NoArg_Exits1WithJsonError', () => {
+    const r = runLocalScript('get-sprint-issues.sh', []);
+    assert.equal(r.exitCode, 1);
+    assert.match(r.stderr, /\{"error":/);
+  });
 });
 
 // ── Happy path: stdout contract ──────────────────────────────────────
@@ -163,6 +277,70 @@ describe('happy-path-stdout', () => {
     assert.equal(r.exitCode, 0, `non-zero exit: ${r.stderr}`);
     assert.match(r.stdout, /Closed work item #1234/);
   });
+
+  test('local_GetIssue_HappyPath_MatchesGoldenMarkdown', () => {
+    const r = runLocalScript('get-issue.sh', ['1234']);
+    assert.equal(r.exitCode, 0, `non-zero exit: ${r.stderr}`);
+    assert.equal(normalize(r.stdout), normalize(readGolden('local', 'get-issue.happy.md')));
+  });
+
+  test('local_CloseIssue_HappyPath_ExitsZero', () => {
+    const r = runLocalScript('close-issue.sh', ['1234']);
+    assert.equal(r.exitCode, 0, `non-zero exit: ${r.stderr}`);
+    assert.match(r.stdout, /Closed task #1234/);
+  });
+
+  test('local_CreateIssue_HappyPath_CreatesFileAndPrintsId', () => {
+    const result = runLocalScriptKeep('create-issue.sh', ['New task', 'A body', 'feature']);
+    try {
+      assert.equal(result.exitCode, 0, `non-zero exit: ${result.stderr}`);
+      assert.match(result.stdout, /1237/);
+      const newFile = path.join(result.issuesDir, '1237.md');
+      assert.ok(fs.existsSync(newFile), 'Expected 1237.md to be created');
+      const content = fs.readFileSync(newFile, 'utf8');
+      assert.match(content, /title: New task/);
+      assert.match(content, /state: open/);
+      assert.match(content, /labels: \[feature\]/);
+    } finally { cleanup(result.root); }
+  });
+
+  test('local_ListIssues_HappyPath_ReturnsOpenTasksJSON', () => {
+    const r = runLocalScript('list-issues.sh', []);
+    assert.equal(r.exitCode, 0, `non-zero exit: ${r.stderr}`);
+    const items = JSON.parse(r.stdout);
+    assert.ok(Array.isArray(items));
+    assert.equal(items.length, 2);
+    assert.equal(items[0].id, 1234);
+    assert.equal(items[0].state, 'open');
+    assert.equal(items[1].id, 1235);
+  });
+
+  test('local_GetIssueChildren_HappyPath_ReturnsChildren', () => {
+    const r = runLocalScript('get-issue-children.sh', ['1234']);
+    assert.equal(r.exitCode, 0, `non-zero exit: ${r.stderr}`);
+    assert.match(r.stdout, /Child Tasks for Task #1234/);
+    assert.match(r.stdout, /#1235/);
+  });
+
+  test('local_AddLabel_HappyPath_AddsLabel', () => {
+    const result = runLocalScriptKeep('add-label.sh', ['1234', 'urgent']);
+    try {
+      assert.equal(result.exitCode, 0, `non-zero exit: ${result.stderr}`);
+      assert.match(result.stdout, /Added label/);
+      const content = fs.readFileSync(path.join(result.issuesDir, '1234.md'), 'utf8');
+      assert.match(content, /urgent/);
+    } finally { cleanup(result.root); }
+  });
+
+  test('local_RemoveLabel_HappyPath_RemovesLabel', () => {
+    const result = runLocalScriptKeep('remove-label.sh', ['1234', 'feature']);
+    try {
+      assert.equal(result.exitCode, 0, `non-zero exit: ${result.stderr}`);
+      assert.match(result.stdout, /Removed label/);
+      const content = fs.readFileSync(path.join(result.issuesDir, '1234.md'), 'utf8');
+      assert.ok(!content.match(/labels:.*feature/));
+    } finally { cleanup(result.root); }
+  });
 });
 
 // ── Failure-mode contract ────────────────────────────────────────────
@@ -202,6 +380,39 @@ describe('failure-modes', () => {
     const r = runScript('todoist', 'get-issue.sh', ['1234'], { fixtureAuth: 'expired' });
     assert.equal(r.exitCode, 1);
     assert.match(r.stderr, /auth/i);
+  });
+
+  test('local_GetIssue_NotFound_Exits1WithJsonStderr', () => {
+    const r = runLocalScript('get-issue.sh', ['9999']);
+    assert.equal(r.exitCode, 1);
+    assert.match(r.stderr, /\{"error":/);
+  });
+
+  test('local_CloseIssue_AlreadyClosed_Exits1WithError', () => {
+    const r = runLocalScript('close-issue.sh', ['1236']);
+    assert.equal(r.exitCode, 1);
+    assert.match(r.stderr, /already closed/);
+  });
+
+  test('local_GetIssue_MissingDir_Exits1WithAuthError', () => {
+    // Run with a non-existent issues dir to trigger check_auth_local failure
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'tracker-local-nodir-'));
+    const adapterDir = path.join(tmp, 'local');
+    fs.cpSync(path.join(ADAPTERS_DIR, 'local'), adapterDir, { recursive: true });
+    fs.cpSync(path.join(ADAPTERS_DIR, 'lib'), path.join(tmp, 'lib'), { recursive: true });
+    try {
+      const env = {
+        ...process.env,
+        LOCAL_ISSUES_DIR: path.join(tmp, 'nonexistent'),
+        RETRY_BACKOFF_1: '0',
+        RETRY_BACKOFF_2: '0',
+      };
+      const result = spawnSync('bash', [path.join(adapterDir, 'get-issue.sh'), '1234'], {
+        encoding: 'utf8', env, cwd: tmp, timeout: 15000,
+      });
+      assert.equal(result.status, 1);
+      assert.match(result.stderr, /not found/i);
+    } finally { cleanup(tmp); }
   });
 });
 
@@ -261,7 +472,7 @@ describe('retry', () => {
 // ── Contract presence (8 task scripts, D14) ─────────────────────────
 
 describe('contract-presence', () => {
-  for (const adapter of ['ado', 'github', 'todoist']) {
+  for (const adapter of ['ado', 'github', 'todoist', 'local']) {
     test(`${adapter}_HasAllContractScripts`, () => {
       const required = [
         'get-issue.sh',
@@ -284,6 +495,7 @@ describe('contract-presence', () => {
     test(`${adapter}_AllScriptsSourceSharedLibs`, () => {
       const dir = path.join(ADAPTERS_DIR, adapter);
       for (const f of fs.readdirSync(dir)) {
+        if (!f.endsWith('.sh')) continue;
         const txt = fs.readFileSync(path.join(dir, f), 'utf8');
         assert.match(txt, /source.*lib\/retry\.sh/, `${f} must source retry.sh`);
         assert.match(txt, /source.*lib\/auth-check\.sh/, `${f} must source auth-check.sh`);

--- a/trackers/__tests__/fixtures/local-issues/1234.md
+++ b/trackers/__tests__/fixtures/local-issues/1234.md
@@ -1,0 +1,15 @@
+---
+id: 1234
+title: Implement login flow
+state: open
+labels: [feature, priority-high]
+parent: null
+created: 2026-07-11T14:32:05Z
+closed: null
+close_reason: null
+---
+
+Users need to be able to log in.
+
+## Acceptance criteria
+- Valid credentials authenticate the user

--- a/trackers/__tests__/fixtures/local-issues/1235.md
+++ b/trackers/__tests__/fixtures/local-issues/1235.md
@@ -1,0 +1,12 @@
+---
+id: 1235
+title: Add dark mode toggle
+state: open
+labels: [feature]
+parent: 1234
+created: 2026-07-11T15:00:00Z
+closed: null
+close_reason: null
+---
+
+Child task of login flow for dark mode support.

--- a/trackers/__tests__/fixtures/local-issues/1236.md
+++ b/trackers/__tests__/fixtures/local-issues/1236.md
@@ -1,0 +1,12 @@
+---
+id: 1236
+title: Fix header alignment
+state: closed
+labels: [bug]
+parent: null
+created: 2026-07-10T09:00:00Z
+closed: 2026-07-11T12:00:00Z
+close_reason: completed
+---
+
+The header was misaligned on mobile viewports.

--- a/trackers/__tests__/golden/local/get-issue.happy.md
+++ b/trackers/__tests__/golden/local/get-issue.happy.md
@@ -1,0 +1,11 @@
+# Task #1234: Implement login flow
+
+**State:** OPEN
+**Labels:** feature, priority-high
+**Parent:** None
+
+## Description
+Users need to be able to log in.
+
+## Acceptance criteria
+- Valid credentials authenticate the user

--- a/trackers/lib/auth-check.sh
+++ b/trackers/lib/auth-check.sh
@@ -87,3 +87,13 @@ check_auth_todoist() {
     exit 1
   fi
 }
+
+check_auth_local() {
+  # Local backend has no external CLI — verify the tasks/issues/ directory exists.
+  # create-issue.sh creates it on first use; all other scripts require it.
+  local issues_dir="${LOCAL_ISSUES_DIR:-tasks/issues}"
+  if [ ! -d "$issues_dir" ]; then
+    echo "{\"error\": \"Local issues directory not found: $issues_dir. Run create-issue.sh first or create it manually.\"}" >&2
+    exit 1
+  fi
+}

--- a/trackers/lib/render-todo.sh
+++ b/trackers/lib/render-todo.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# render-todo.sh — Shared todo.md renderer (D9, D10, D17)
+#
+# Usage: bash trackers/lib/render-todo.sh [issues_dir]
+#
+# Reads task files from issues_dir (default: tasks/issues/), generates
+# tasks/todo.md with open tasks grouped by label plus recently closed (max 20).
+#
+# Determinism: same input → byte-identical output (stable sort by id).
+# Bash 3.2 compatible (no associative arrays).
+
+set -o pipefail
+
+ISSUES_DIR="${1:-tasks/issues}"
+TODO_FILE="${TODO_OUTPUT:-tasks/todo.md}"
+
+# Ensure output directory exists
+mkdir -p "$(dirname "$TODO_FILE")"
+
+# Use a temp directory for intermediate data
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+mkdir -p "$WORK_DIR/labels"
+
+total_open=0
+total_closed=0
+
+# --- Pass 1: collect open tasks ---
+for f in "$ISSUES_DIR"/*.md; do
+  [ -f "$f" ] || continue
+  id=$(basename "$f" .md)
+  # Skip non-numeric filenames
+  case "$id" in
+    *[!0-9]*) continue ;;
+  esac
+
+  state=$(grep -m1 '^state:' "$f" | sed 's/^state: *//')
+  if [ "$state" = "open" ]; then
+    total_open=$((total_open + 1))
+    title=$(grep -m1 '^title:' "$f" | sed 's/^title: *//')
+    labels_raw=$(grep -m1 '^labels:' "$f" | sed 's/^labels: *//;s/\[//;s/\]//')
+
+    if [ -z "$labels_raw" ]; then
+      echo "${id}|${title}" >> "$WORK_DIR/labels/_unlabeled"
+    else
+      IFS=',' read -ra parts <<< "$labels_raw"
+      for part in "${parts[@]}"; do
+        label=$(echo "$part" | sed 's/^ *//;s/ *$//')
+        [ -z "$label" ] && continue
+        echo "${id}|${title}" >> "$WORK_DIR/labels/${label}"
+      done
+    fi
+  elif [ "$state" = "closed" ]; then
+    total_closed=$((total_closed + 1))
+    closed_date=$(grep -m1 '^closed:' "$f" | sed 's/^closed: *//')
+    echo "${closed_date}|${id}" >> "$WORK_DIR/closed_all"
+  fi
+done
+
+# --- Render output ---
+{
+  echo "<!-- AUTO-GENERATED — do not edit. -->"
+  echo ""
+  echo "# Task Board"
+  echo ""
+  echo "_${total_open} open, ${total_closed} closed_"
+  echo ""
+
+  if [ "$total_open" -eq 0 ]; then
+    echo "_No open tasks._"
+    echo ""
+  else
+    # Print each label group (sorted by label name)
+    for label_file in $(ls "$WORK_DIR/labels/" 2>/dev/null | grep -v '^_unlabeled$' | sort); do
+      echo "## ${label_file}"
+      echo ""
+      sort -t'|' -k1 -n "$WORK_DIR/labels/${label_file}" | while IFS='|' read -r tid ttitle; do
+        [ -z "$tid" ] && continue
+        echo "- [ ] #${tid} — ${ttitle}"
+      done
+      echo ""
+    done
+
+    # Print unlabeled
+    if [ -f "$WORK_DIR/labels/_unlabeled" ]; then
+      echo "## Unlabeled"
+      echo ""
+      sort -t'|' -k1 -n "$WORK_DIR/labels/_unlabeled" | while IFS='|' read -r tid ttitle; do
+        [ -z "$tid" ] && continue
+        echo "- [ ] #${tid} — ${ttitle}"
+      done
+      echo ""
+    fi
+  fi
+
+  # Recently closed section (most recent 20 by closed date)
+  if [ -f "$WORK_DIR/closed_all" ]; then
+    echo "---"
+    echo ""
+    echo "## Recently Closed"
+    echo ""
+    sort -r "$WORK_DIR/closed_all" | head -20 | while IFS='|' read -r _cdate cid; do
+      ctitle=$(grep -m1 '^title:' "$ISSUES_DIR/${cid}.md" | sed 's/^title: *//')
+      creason=$(grep -m1 '^close_reason:' "$ISSUES_DIR/${cid}.md" | sed 's/^close_reason: *//')
+      [ "$creason" = "null" ] && creason=""
+      reason_suffix=""
+      [ -n "$creason" ] && reason_suffix=" (${creason})"
+      echo "- [x] #${cid} — ${ctitle}${reason_suffix}"
+    done
+    echo ""
+  fi
+} > "$WORK_DIR/output.md"
+
+mv "$WORK_DIR/output.md" "$TODO_FILE"

--- a/trackers/local/add-label.sh
+++ b/trackers/local/add-label.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# add-label.sh — Local tracker adapter
+# Usage: bash .claude/trackers/active/add-label.sh <ID> "<label>"
+# Adds a label to the specified task's frontmatter.
+
+set -o pipefail
+
+ISSUE_ID="${1:-}"
+LABEL="${2:-}"
+
+if [ -z "$ISSUE_ID" ] || [ -z "$LABEL" ]; then
+  echo '{"error": "Usage: add-label.sh <ID> \"<label>\""}' >&2
+  exit 1
+fi
+
+source "$(dirname "$0")/../lib/retry.sh"
+source "$(dirname "$0")/../lib/auth-check.sh"
+check_auth_local
+
+ISSUES_DIR="${LOCAL_ISSUES_DIR:-tasks/issues}"
+TASK_FILE="$ISSUES_DIR/${ISSUE_ID}.md"
+
+if [ ! -f "$TASK_FILE" ]; then
+  echo "{\"error\": \"Task $ISSUE_ID not found at $TASK_FILE\"}" >&2
+  exit 1
+fi
+
+# Read current labels
+current_labels=$(grep -m1 '^labels:' "$TASK_FILE" | sed 's/^labels: *//')
+
+# Strip brackets and split
+inner=$(echo "$current_labels" | sed 's/\[//;s/\]//')
+
+# Check if label already exists
+if echo "$inner" | grep -qw "$LABEL"; then
+  echo "Label '$LABEL' already exists on task #${ISSUE_ID}"
+  exit 0
+fi
+
+# Append new label
+if [ -z "$inner" ]; then
+  new_labels="[$LABEL]"
+else
+  new_labels="[${inner}, ${LABEL}]"
+fi
+
+# Update file via temp + mv
+TMP_FILE=$(mktemp)
+trap 'rm -f "$TMP_FILE"' EXIT
+
+sed "s/^labels: .*/labels: ${new_labels}/" "$TASK_FILE" > "$TMP_FILE"
+mv "$TMP_FILE" "$TASK_FILE"
+
+# Regenerate todo.md
+RENDER_SCRIPT="$(dirname "$0")/../lib/render-todo.sh"
+if [ -x "$RENDER_SCRIPT" ] || [ -f "$RENDER_SCRIPT" ]; then
+  bash "$RENDER_SCRIPT" "$ISSUES_DIR" 2>/dev/null || true
+fi
+
+echo "Added label '$LABEL' to task #${ISSUE_ID}"

--- a/trackers/local/close-issue.sh
+++ b/trackers/local/close-issue.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# close-issue.sh — Local tracker adapter
+# Usage: bash .claude/trackers/active/close-issue.sh <ID> ["<reason>"]
+# Closes the specified task. Optional reason defaults to "completed".
+
+set -o pipefail
+
+ISSUE_ID="${1:-}"
+REASON="${2:-completed}"
+
+if [ -z "$ISSUE_ID" ]; then
+  echo '{"error": "Task ID required. Usage: close-issue.sh <ID> [\"<reason>\"]"}' >&2
+  exit 1
+fi
+
+source "$(dirname "$0")/../lib/retry.sh"
+source "$(dirname "$0")/../lib/auth-check.sh"
+check_auth_local
+
+ISSUES_DIR="${LOCAL_ISSUES_DIR:-tasks/issues}"
+TASK_FILE="$ISSUES_DIR/${ISSUE_ID}.md"
+
+if [ ! -f "$TASK_FILE" ]; then
+  echo "{\"error\": \"Task $ISSUE_ID not found at $TASK_FILE\"}" >&2
+  exit 1
+fi
+
+# Check if already closed
+current_state=$(grep -m1 '^state:' "$TASK_FILE" | sed 's/^state: *//')
+if [ "$current_state" = "closed" ]; then
+  echo "{\"error\": \"Task $ISSUE_ID is already closed.\"}" >&2
+  exit 1
+fi
+
+CLOSED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# Update frontmatter fields via temp file + mv (crash-safe)
+TMP_FILE=$(mktemp)
+trap 'rm -f "$TMP_FILE"' EXIT
+
+sed \
+  -e "s/^state: *open/state: closed/" \
+  -e "s/^closed: *null/closed: $CLOSED_AT/" \
+  -e "s/^close_reason: *null/close_reason: $REASON/" \
+  "$TASK_FILE" > "$TMP_FILE"
+
+mv "$TMP_FILE" "$TASK_FILE"
+
+# Regenerate todo.md
+RENDER_SCRIPT="$(dirname "$0")/../lib/render-todo.sh"
+if [ -x "$RENDER_SCRIPT" ] || [ -f "$RENDER_SCRIPT" ]; then
+  bash "$RENDER_SCRIPT" "$ISSUES_DIR" 2>/dev/null || true
+fi
+
+echo "Closed task #${ISSUE_ID}"

--- a/trackers/local/create-issue.sh
+++ b/trackers/local/create-issue.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# create-issue.sh — Local tracker adapter
+# Usage: bash .claude/trackers/active/create-issue.sh "<title>" "<body>" "<label>"
+# Creates a new task file in tasks/issues/ with the next sequential ID.
+# Prints the task id and path on success.
+
+set -o pipefail
+
+TITLE="${1:-}"
+BODY="${2:-}"
+LABEL="${3:-}"
+
+if [ -z "$TITLE" ]; then
+  echo '{"error": "Title required. Usage: create-issue.sh \"<title>\" \"<body>\" [\"<label>\"]"}' >&2
+  exit 1
+fi
+
+source "$(dirname "$0")/../lib/retry.sh"
+source "$(dirname "$0")/../lib/auth-check.sh"
+
+ISSUES_DIR="${LOCAL_ISSUES_DIR:-tasks/issues}"
+
+# Create the directory on first use
+mkdir -p "$ISSUES_DIR"
+
+# Mint next ID: highest existing filename + 1
+_mint_next_id() {
+  local max_id=0
+  for f in "$ISSUES_DIR"/*.md; do
+    [ -f "$f" ] || continue
+    local basename
+    basename=$(basename "$f" .md)
+    if [[ "$basename" =~ ^[0-9]+$ ]] && [ "$basename" -gt "$max_id" ]; then
+      max_id="$basename"
+    fi
+  done
+  echo $((max_id + 1))
+}
+
+# Atomic create with noclobber retry
+MAX_RETRIES=5
+attempt=0
+while [ $attempt -lt $MAX_RETRIES ]; do
+  NEXT_ID=$(_mint_next_id)
+  TASK_FILE="$ISSUES_DIR/${NEXT_ID}.md"
+
+  # Format labels as YAML list
+  if [ -n "$LABEL" ]; then
+    labels_yaml="[$LABEL]"
+  else
+    labels_yaml="[]"
+  fi
+
+  CREATED=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+  CONTENT="---
+id: ${NEXT_ID}
+title: ${TITLE}
+state: open
+labels: ${labels_yaml}
+parent: null
+created: ${CREATED}
+closed: null
+close_reason: null
+---
+
+${BODY}"
+
+  # Atomic write: noclobber prevents overwriting if file appeared between scan and write
+  if (set -o noclobber; echo "$CONTENT" > "$TASK_FILE") 2>/dev/null; then
+    # Regenerate todo.md
+    RENDER_SCRIPT="$(dirname "$0")/../lib/render-todo.sh"
+    if [ -x "$RENDER_SCRIPT" ] || [ -f "$RENDER_SCRIPT" ]; then
+      bash "$RENDER_SCRIPT" "$ISSUES_DIR" 2>/dev/null || true
+    fi
+    echo "${NEXT_ID} ${TASK_FILE}"
+    exit 0
+  fi
+
+  attempt=$((attempt + 1))
+done
+
+echo '{"error": "Failed to create task after retries (ID collision)."}' >&2
+exit 1

--- a/trackers/local/get-issue-children.sh
+++ b/trackers/local/get-issue-children.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# get-issue-children.sh — Local tracker adapter
+# Usage: bash .claude/trackers/active/get-issue-children.sh <ID>
+# Scans tasks/issues/ for tasks whose parent field matches <ID>.
+# Output: markdown-formatted list of children.
+
+set -o pipefail
+
+ISSUE_ID="${1:-}"
+
+if [ -z "$ISSUE_ID" ]; then
+  echo '{"error": "Task ID required. Usage: get-issue-children.sh <ID>"}' >&2
+  exit 1
+fi
+
+source "$(dirname "$0")/../lib/retry.sh"
+source "$(dirname "$0")/../lib/auth-check.sh"
+check_auth_local
+
+ISSUES_DIR="${LOCAL_ISSUES_DIR:-tasks/issues}"
+
+# Verify parent task exists
+PARENT_FILE="$ISSUES_DIR/${ISSUE_ID}.md"
+if [ ! -f "$PARENT_FILE" ]; then
+  echo "{\"error\": \"Task $ISSUE_ID not found at $PARENT_FILE\"}" >&2
+  exit 1
+fi
+
+echo "# Child Tasks for Task #${ISSUE_ID}"
+echo ""
+
+children_found=0
+open_count=0
+closed_count=0
+
+for f in "$ISSUES_DIR"/*.md; do
+  [ -f "$f" ] || continue
+  parent_val=$(grep -m1 '^parent:' "$f" | sed 's/^parent: *//')
+  if [ "$parent_val" = "$ISSUE_ID" ]; then
+    child_id=$(basename "$f" .md)
+    child_title=$(grep -m1 '^title:' "$f" | sed 's/^title: *//')
+    child_state=$(grep -m1 '^state:' "$f" | sed 's/^state: *//')
+
+    if [ "$child_state" = "closed" ]; then
+      marker="x"
+      closed_count=$((closed_count + 1))
+    else
+      marker=" "
+      open_count=$((open_count + 1))
+    fi
+
+    display_state=$(echo "$child_state" | tr '[:lower:]' '[:upper:]')
+    echo "- [$marker] #${child_id} ${child_title} (${display_state})"
+    children_found=$((children_found + 1))
+  fi
+done
+
+if [ $children_found -eq 0 ]; then
+  echo "_No child tasks found for task #${ISSUE_ID}._"
+else
+  echo ""
+  total=$((open_count + closed_count))
+  echo "_Progress: ${closed_count}/${total} complete (${open_count} open)_"
+fi

--- a/trackers/local/get-issue.sh
+++ b/trackers/local/get-issue.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# get-issue.sh — Local tracker adapter
+# Usage: bash .claude/trackers/active/get-issue.sh <ID>
+# Returns full details of a single task from tasks/issues/<ID>.md.
+
+set -o pipefail
+
+ISSUE_ID="${1:-}"
+
+if [ -z "$ISSUE_ID" ]; then
+  echo '{"error": "Task ID required. Usage: get-issue.sh <ID>"}' >&2
+  exit 1
+fi
+
+source "$(dirname "$0")/../lib/retry.sh"
+source "$(dirname "$0")/../lib/auth-check.sh"
+check_auth_local
+
+ISSUES_DIR="${LOCAL_ISSUES_DIR:-tasks/issues}"
+TASK_FILE="$ISSUES_DIR/${ISSUE_ID}.md"
+
+if [ ! -f "$TASK_FILE" ]; then
+  echo "{\"error\": \"Task $ISSUE_ID not found at $TASK_FILE\"}" >&2
+  exit 1
+fi
+
+# Parse frontmatter (between --- delimiters)
+in_frontmatter=false
+frontmatter_done=false
+title=""
+state=""
+labels=""
+parent=""
+body=""
+
+while IFS= read -r line || [ -n "$line" ]; do
+  if [ "$frontmatter_done" = "true" ]; then
+    if [ -z "$body" ]; then
+      body="$line"
+    else
+      body="$body
+$line"
+    fi
+    continue
+  fi
+
+  if [ "$line" = "---" ]; then
+    if [ "$in_frontmatter" = "true" ]; then
+      frontmatter_done=true
+    else
+      in_frontmatter=true
+    fi
+    continue
+  fi
+
+  if [ "$in_frontmatter" = "true" ]; then
+    key=$(echo "$line" | sed -n 's/^\([a-z_]*\):.*/\1/p')
+    val=$(echo "$line" | sed -n 's/^[a-z_]*: *//p')
+    case "$key" in
+      title) title="$val" ;;
+      state) state="$val" ;;
+      labels) labels="$val" ;;
+      parent) parent="$val" ;;
+    esac
+  fi
+done < "$TASK_FILE"
+
+# Strip leading blank line from body
+body=$(echo "$body" | sed '/./,$!d')
+
+# Format labels for display (normalize: strip brackets, collapse whitespace around commas)
+display_labels=$(echo "$labels" | sed 's/\[//;s/\]//' | sed 's/ *, */,/g' | sed 's/,/, /g')
+display_labels=$(echo "$display_labels" | sed 's/^ *//;s/ *$//')
+[ -z "$display_labels" ] && display_labels="None"
+
+# Format state for display
+display_state=$(echo "$state" | tr '[:lower:]' '[:upper:]')
+
+# Format parent
+display_parent="None"
+[ -n "$parent" ] && [ "$parent" != "null" ] && display_parent="#$parent"
+
+cat <<EOF
+# Task #${ISSUE_ID}: ${title}
+
+**State:** ${display_state}
+**Labels:** ${display_labels}
+**Parent:** ${display_parent}
+
+## Description
+${body:-_No description_}
+EOF

--- a/trackers/local/get-sprint-issues.sh
+++ b/trackers/local/get-sprint-issues.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# get-sprint-issues.sh — Local tracker adapter
+# Usage: bash .claude/trackers/active/get-sprint-issues.sh <SPRINT_NUMBER>
+# Parses the Master Status Table in tasks/sprint<N>.md, resolves IDs to task
+# files, and emits a standard JSON list.
+
+set -o pipefail
+
+SPRINT="${1:-}"
+
+if [ -z "$SPRINT" ]; then
+  echo '{"error": "Sprint number required. Usage: get-sprint-issues.sh <SPRINT_NUMBER>"}' >&2
+  exit 1
+fi
+
+source "$(dirname "$0")/../lib/retry.sh"
+source "$(dirname "$0")/../lib/auth-check.sh"
+check_auth_local
+
+ISSUES_DIR="${LOCAL_ISSUES_DIR:-tasks/issues}"
+
+# Find sprint file: exact match first, then highest-numbered fallback
+SPRINT_FILE="tasks/sprint${SPRINT}.md"
+if [ ! -f "$SPRINT_FILE" ]; then
+  # Fallback: find highest-numbered sprint file
+  SPRINT_FILE=""
+  for f in tasks/sprint*.md; do
+    [ -f "$f" ] || continue
+    SPRINT_FILE="$f"
+  done
+  if [ -z "$SPRINT_FILE" ]; then
+    echo "{\"error\": \"No sprint file found for sprint $SPRINT\"}" >&2
+    exit 1
+  fi
+fi
+
+# Parse Master Status Table rows
+# Format: | Story ID | Title | SP | Priority | Status | Owner |
+# Skip header and separator rows
+json_items="[]"
+
+while IFS= read -r line; do
+  # Skip non-table rows, header row, separator row, and placeholder rows
+  echo "$line" | grep -q '^|' || continue
+  echo "$line" | grep -q '^\s*|[-: ]*|' && continue
+  echo "$line" | grep -q 'Story ID' && continue
+  echo "$line" | grep -q '<!-- ' && continue
+
+  # Extract story ID (first column)
+  story_id=$(echo "$line" | awk -F'|' '{print $2}' | sed 's/^ *//;s/ *$//' | sed 's/#//')
+
+  # Skip empty or non-numeric IDs
+  [[ "$story_id" =~ ^[0-9]+$ ]] || continue
+
+  # Resolve from task file if it exists, otherwise use table data
+  task_file="$ISSUES_DIR/${story_id}.md"
+  if [ -f "$task_file" ]; then
+    title=$(grep -m1 '^title:' "$task_file" | sed 's/^title: *//')
+    state=$(grep -m1 '^state:' "$task_file" | sed 's/^state: *//')
+    labels_raw=$(grep -m1 '^labels:' "$task_file" | sed 's/^labels: *//;s/\[//;s/\]//')
+
+    # Build labels JSON array
+    labels_json="[]"
+    if [ -n "$labels_raw" ]; then
+      labels_json=$(echo "$labels_raw" | awk -F', *' '{
+        printf "["
+        for (i=1; i<=NF; i++) {
+          gsub(/^ +| +$/, "", $i)
+          if ($i != "") {
+            if (i > 1) printf ","
+            printf "\"%s\"", $i
+          }
+        }
+        printf "]"
+      }')
+    fi
+
+    item="{\"id\":${story_id},\"title\":\"${title}\",\"state\":\"${state}\",\"labels\":${labels_json},\"assignees\":[],\"url\":\"${task_file}\"}"
+  else
+    # Use table data directly
+    title=$(echo "$line" | awk -F'|' '{print $3}' | sed 's/^ *//;s/ *$//')
+    status=$(echo "$line" | awk -F'|' '{print $6}' | sed 's/^ *//;s/ *$//')
+
+    # Map status table values to open/closed
+    state="open"
+    if echo "$status" | grep -qi "done"; then
+      state="closed"
+    fi
+
+    item="{\"id\":${story_id},\"title\":\"${title}\",\"state\":\"${state}\",\"labels\":[],\"assignees\":[],\"url\":\"\"}"
+  fi
+
+  json_items=$(echo "$json_items" | sed "s/\]$/, ${item}]/" | sed 's/\[, /[/')
+
+done < "$SPRINT_FILE"
+
+echo "$json_items"

--- a/trackers/local/list-issues.sh
+++ b/trackers/local/list-issues.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# list-issues.sh — Local tracker adapter
+# Usage: bash .claude/trackers/active/list-issues.sh
+# Returns all open tasks as a JSON array.
+# Output: JSON array [{id, title, state, labels, assignees, url}]
+
+set -o pipefail
+
+source "$(dirname "$0")/../lib/retry.sh"
+source "$(dirname "$0")/../lib/auth-check.sh"
+check_auth_local
+
+ISSUES_DIR="${LOCAL_ISSUES_DIR:-tasks/issues}"
+
+# Regenerate todo.md on read (D10: self-healing)
+RENDER_SCRIPT="$(dirname "$0")/../lib/render-todo.sh"
+if [ -x "$RENDER_SCRIPT" ] || [ -f "$RENDER_SCRIPT" ]; then
+  bash "$RENDER_SCRIPT" "$ISSUES_DIR" 2>/dev/null || true
+fi
+
+# Collect all open tasks sorted by ID
+first=true
+echo -n "["
+
+for f in $(ls "$ISSUES_DIR"/*.md 2>/dev/null | sort -t/ -k3 -n); do
+  [ -f "$f" ] || continue
+
+  state=$(grep -m1 '^state:' "$f" | sed 's/^state: *//')
+  [ "$state" = "open" ] || continue
+
+  id=$(basename "$f" .md)
+  title=$(grep -m1 '^title:' "$f" | sed 's/^title: *//')
+  labels_raw=$(grep -m1 '^labels:' "$f" | sed 's/^labels: *//;s/\[//;s/\]//')
+
+  # Build labels JSON array
+  labels_json="[]"
+  if [ -n "$labels_raw" ]; then
+    labels_json=$(echo "$labels_raw" | awk -F', *' '{
+      printf "["
+      for (i=1; i<=NF; i++) {
+        gsub(/^ +| +$/, "", $i)
+        if ($i != "") {
+          if (i > 1) printf ","
+          printf "\"%s\"", $i
+        }
+      }
+      printf "]"
+    }')
+  fi
+
+  # Escape title for JSON (handle double quotes)
+  escaped_title=$(echo "$title" | sed 's/"/\\"/g')
+
+  if [ "$first" = "true" ]; then
+    first=false
+  else
+    echo -n ","
+  fi
+
+  echo -n "{\"id\":${id},\"title\":\"${escaped_title}\",\"state\":\"open\",\"labels\":${labels_json},\"assignees\":[],\"url\":\"${f}\"}"
+done
+
+echo "]"

--- a/trackers/local/remove-label.sh
+++ b/trackers/local/remove-label.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# remove-label.sh — Local tracker adapter
+# Usage: bash .claude/trackers/active/remove-label.sh <ID> "<label>"
+# Removes a label from the specified task's frontmatter.
+
+set -o pipefail
+
+ISSUE_ID="${1:-}"
+LABEL="${2:-}"
+
+if [ -z "$ISSUE_ID" ] || [ -z "$LABEL" ]; then
+  echo '{"error": "Usage: remove-label.sh <ID> \"<label>\""}' >&2
+  exit 1
+fi
+
+source "$(dirname "$0")/../lib/retry.sh"
+source "$(dirname "$0")/../lib/auth-check.sh"
+check_auth_local
+
+ISSUES_DIR="${LOCAL_ISSUES_DIR:-tasks/issues}"
+TASK_FILE="$ISSUES_DIR/${ISSUE_ID}.md"
+
+if [ ! -f "$TASK_FILE" ]; then
+  echo "{\"error\": \"Task $ISSUE_ID not found at $TASK_FILE\"}" >&2
+  exit 1
+fi
+
+# Read current labels
+current_labels=$(grep -m1 '^labels:' "$TASK_FILE" | sed 's/^labels: *//')
+
+# Strip brackets and split into array
+inner=$(echo "$current_labels" | sed 's/\[//;s/\]//')
+
+# Remove the target label (comma-separated, trim spaces)
+new_inner=""
+IFS=',' read -ra PARTS <<< "$inner"
+for part in "${PARTS[@]}"; do
+  trimmed=$(echo "$part" | sed 's/^ *//;s/ *$//')
+  if [ "$trimmed" != "$LABEL" ]; then
+    if [ -z "$new_inner" ]; then
+      new_inner="$trimmed"
+    else
+      new_inner="$new_inner, $trimmed"
+    fi
+  fi
+done
+
+new_labels="[${new_inner}]"
+
+# Update file via temp + mv
+TMP_FILE=$(mktemp)
+trap 'rm -f "$TMP_FILE"' EXIT
+
+sed "s/^labels: .*/labels: ${new_labels}/" "$TASK_FILE" > "$TMP_FILE"
+mv "$TMP_FILE" "$TASK_FILE"
+
+# Regenerate todo.md
+RENDER_SCRIPT="$(dirname "$0")/../lib/render-todo.sh"
+if [ -x "$RENDER_SCRIPT" ] || [ -f "$RENDER_SCRIPT" ]; then
+  bash "$RENDER_SCRIPT" "$ISSUES_DIR" 2>/dev/null || true
+fi
+
+echo "Removed label '$LABEL' from task #${ISSUE_ID}"


### PR DESCRIPTION
## Summary

Implements `trackers/local/` — full 8-script task interface over `tasks/issues/<id>.md` markdown files with YAML frontmatter (D6–D8, D14, D16). Depends on WS1 (code-platform split).

- `trackers/local/` — 8 scripts: get-issue, create-issue, close-issue, add-label, remove-label, get-issue-children, get-sprint-issues, list-issues
- `trackers/lib/render-todo.sh` — shared renderer (D17): grouped by label, sorted by ID, recently-closed section, deterministic output
- `hooks/todo-render-trigger.js` — PostToolUse hook for self-healing todo.md regeneration when task files are hand-edited (D10)
- `check_auth_local` added to `trackers/lib/auth-check.sh`
- Conformance suite extended with new fixture strategy for local backend. 308 tests pass.

## Key design decisions

- Bash 3.2 compatible (no associative arrays or `${var^^}`)
- Atomic create via `set -o noclobber` with retry
- Crash-safe writes via temp file + `mv`
- Loud failure on all error paths (D16)
- Self-healing: mutating + read scripts regenerate todo.md; hook catches hand-edits

## Test plan

- [x] `npm test` — 308 pass, 0 fail
- [x] `npm run lint` — clean
- [x] E2E: create → get → label → children → list → close with todo.md regenerating
- [x] Hook unit tests (5 cases: path matching, manifest reading, fail-open)
- [x] Conformance: arg-validation, happy-path, failure-modes, contract-presence for `local`