### PR TITLE
feat: add sync automation — sweep hook, mode-aware /sync-tracker, pre-compact fix (WS4)

### DIFF
--- a/examples/settings.json
+++ b/examples/settings.json
@@ -52,6 +52,10 @@
           {
             "type": "command",
             "command": "echo \"SESSION START: Before doing anything else — read tasks/lessons.md, todo.md, pr-queue.md, and flags-and-notes.md\""
+          },
+          {
+            "type": "command",
+            "command": "node \"/home/username/.claude/hooks/tracker-sync.js\" start"
           }
         ]
       }
@@ -63,6 +67,10 @@
           {
             "type": "command",
             "command": "node \"/home/username/.claude/hooks/session-log.js\""
+          },
+          {
+            "type": "command",
+            "command": "node \"/home/username/.claude/hooks/tracker-sync.js\" end"
           }
         ]
       }

--- a/hooks/__tests__/tracker-sync.test.js
+++ b/hooks/__tests__/tracker-sync.test.js
@@ -1,0 +1,312 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const HOOK = path.join(__dirname, '..', 'tracker-sync.js');
+
+// --- Fixture helpers ---
+
+function makeFixture({
+  tracker = 'local',
+  trackerMirror = false,
+  withBackup = false,
+  withIssues = [],
+} = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tracker-sync-'));
+  const claudeDir = path.join(dir, '.claude');
+  fs.mkdirSync(claudeDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(claudeDir, '.harness-manifest.json'),
+    JSON.stringify({ tracker, trackerMirror })
+  );
+
+  if (withBackup) {
+    fs.mkdirSync(path.join(dir, 'tasks'), { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'tasks', 'todo-manual-backup.md'),
+      '- [ ] Migrate old tasks\n- [x] Already done\n'
+    );
+  }
+
+  if (withIssues.length) {
+    const issuesDir = path.join(dir, 'tasks', 'issues');
+    fs.mkdirSync(issuesDir, { recursive: true });
+    for (const issue of withIssues) {
+      const content = [
+        `id: ${issue.id}`,
+        `title: ${issue.title}`,
+        `state: ${issue.state || 'open'}`,
+        `labels: [${(issue.labels || []).join(', ')}]`,
+        `created: 2026-01-01T00:00:00Z`,
+      ];
+      if (issue.state === 'closed') {
+        content.push(`closed: 2026-01-02T00:00:00Z`);
+        content.push(`close_reason: completed`);
+      }
+      fs.writeFileSync(path.join(issuesDir, `${issue.id}.md`), content.join('\n') + '\n');
+    }
+  }
+
+  return { root: dir };
+}
+
+function cleanup(root) {
+  try { fs.rmSync(root, { recursive: true, force: true }); } catch { /* ignore */ }
+}
+
+function runHookProcess(phase, { cwd, env } = {}) {
+  const result = spawnSync(
+    process.execPath,
+    [HOOK, phase],
+    {
+      input: JSON.stringify({}),
+      encoding: 'utf8',
+      cwd: cwd || process.cwd(),
+      env: { ...process.env, ...env, PATH: process.env.PATH },
+      timeout: 15000,
+    }
+  );
+  return { stdout: result.stdout, stderr: result.stderr, exitCode: result.status };
+}
+
+// --- Mode gating tests ---
+
+test('exits 0 (no-op) when manifest is missing', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tracker-sync-nomanifest-'));
+  try {
+    const result = runHookProcess('start', { cwd: dir });
+    assert.equal(result.exitCode, 0);
+  } finally { cleanup(dir); }
+});
+
+test('exits 0 (no-op) when tracker is null in manifest', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tracker-sync-notracker-'));
+  const claudeDir = path.join(dir, '.claude');
+  fs.mkdirSync(claudeDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(claudeDir, '.harness-manifest.json'),
+    JSON.stringify({ tracker: null })
+  );
+  try {
+    const result = runHookProcess('start', { cwd: dir });
+    assert.equal(result.exitCode, 0);
+  } finally { cleanup(dir); }
+});
+
+test('exits 0 for session end when manifest is missing', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tracker-sync-nomanifest-'));
+  try {
+    const result = runHookProcess('end', { cwd: dir });
+    assert.equal(result.exitCode, 0);
+  } finally { cleanup(dir); }
+});
+
+// --- Mode derivation tests ---
+
+test('mode = local when tracker is local', () => {
+  const { root } = makeFixture({ tracker: 'local' });
+  try {
+    const result = runHookProcess('start', { cwd: root });
+    assert.equal(result.exitCode, 0);
+  } finally { cleanup(root); }
+});
+
+test('mode = both when tracker is github + trackerMirror true', () => {
+  const { root } = makeFixture({ tracker: 'github', trackerMirror: true });
+  try {
+    const result = runHookProcess('start', { cwd: root });
+    assert.equal(result.exitCode, 0);
+  } finally { cleanup(root); }
+});
+
+test('mode = tracker when tracker is github + no mirror', () => {
+  const { root } = makeFixture({ tracker: 'github', trackerMirror: false });
+  try {
+    const result = runHookProcess('start', { cwd: root });
+    assert.equal(result.exitCode, 0);
+  } finally { cleanup(root); }
+});
+
+// --- Backup notice tests ---
+
+test('SessionStart injects backup notice when todo-manual-backup.md exists', () => {
+  const { root } = makeFixture({ tracker: 'local', withBackup: true });
+  try {
+    const result = runHookProcess('start', { cwd: root });
+    assert.equal(result.exitCode, 0);
+    const output = result.stdout;
+    if (output) {
+      const parsed = JSON.parse(output);
+      const ctx = parsed.hookSpecificOutput?.additionalContext || '';
+      assert.ok(ctx.includes('todo-manual-backup.md'), 'should mention backup file');
+      assert.ok(ctx.includes('--import-backup'), 'should suggest --import-backup flag');
+    }
+  } finally { cleanup(root); }
+});
+
+test('SessionStart does NOT inject backup notice when no backup exists', () => {
+  const { root } = makeFixture({ tracker: 'local' });
+  try {
+    const result = runHookProcess('start', { cwd: root });
+    assert.equal(result.exitCode, 0);
+    if (result.stdout) {
+      const parsed = JSON.parse(result.stdout);
+      const ctx = parsed.hookSpecificOutput?.additionalContext || '';
+      assert.ok(!ctx.includes('todo-manual-backup.md'), 'should not mention backup file');
+    }
+  } finally { cleanup(root); }
+});
+
+// --- Evidence extraction unit tests (via require) ---
+
+// We test the module's pure functions by loading them directly.
+// The hook file exports nothing (it's a script), so we extract
+// the functions by reading the source and evaluating them.
+
+const hookSource = fs.readFileSync(HOOK, 'utf8');
+
+function extractFunction(name, source) {
+  const pattern = new RegExp(`function ${name}\\b[^]*?\\n\\}`);
+  const m = source.match(pattern);
+  if (!m) throw new Error(`Could not extract function ${name}`);
+  return new Function('return ' + m[0])();
+}
+
+const extractClosingRefs = extractFunction('extractClosingRefs', hookSource);
+const extractTaskTrailers = extractFunction('extractTaskTrailers', hookSource);
+
+test('extractClosingRefs: matches "Closes #123"', () => {
+  const refs = extractClosingRefs('This PR\n\nCloses #123');
+  assert.equal(refs.length, 1);
+  assert.equal(refs[0].type, 'github');
+  assert.equal(refs[0].id, '123');
+});
+
+test('extractClosingRefs: matches "Fixes #456" case-insensitive', () => {
+  const refs = extractClosingRefs('fixes #456');
+  assert.equal(refs.length, 1);
+  assert.equal(refs[0].id, '456');
+});
+
+test('extractClosingRefs: matches "Resolves #789"', () => {
+  const refs = extractClosingRefs('Resolves #789 and more');
+  assert.equal(refs.length, 1);
+  assert.equal(refs[0].id, '789');
+});
+
+test('extractClosingRefs: matches multiple refs', () => {
+  const refs = extractClosingRefs('Closes #1\nFixes #2\nResolves #3');
+  assert.equal(refs.length, 3);
+});
+
+test('extractClosingRefs: matches ADO "Fixes AB#204"', () => {
+  const refs = extractClosingRefs('Fixes AB#204');
+  assert.equal(refs.length, 1);
+  assert.equal(refs[0].type, 'ado');
+  assert.equal(refs[0].id, '204');
+});
+
+test('extractClosingRefs: returns empty for no refs', () => {
+  const refs = extractClosingRefs('Just a regular PR body with issue #42 mention');
+  assert.equal(refs.length, 0);
+});
+
+test('extractClosingRefs: returns empty for null/empty', () => {
+  assert.deepEqual(extractClosingRefs(null), []);
+  assert.deepEqual(extractClosingRefs(''), []);
+});
+
+test('extractTaskTrailers: matches anchored "Task: 42"', () => {
+  const refs = extractTaskTrailers('Some PR body\n\nTask: 42');
+  assert.equal(refs.length, 1);
+  assert.equal(refs[0].type, 'local');
+  assert.equal(refs[0].id, '42');
+});
+
+test('extractTaskTrailers: matches multiple trailers', () => {
+  const refs = extractTaskTrailers('Task: 1\nTask: 2\nTask: 3');
+  assert.equal(refs.length, 3);
+});
+
+test('extractTaskTrailers: does NOT match prose "builds on task 42"', () => {
+  const refs = extractTaskTrailers('This builds on task 42 and extends it');
+  assert.equal(refs.length, 0);
+});
+
+test('extractTaskTrailers: does NOT match "Task: 42 extra text"', () => {
+  const refs = extractTaskTrailers('Task: 42 extra text');
+  assert.equal(refs.length, 0);
+});
+
+test('extractTaskTrailers: does NOT match indented trailer', () => {
+  const refs = extractTaskTrailers('  Task: 42');
+  assert.equal(refs.length, 0);
+});
+
+test('extractTaskTrailers: returns empty for null/empty', () => {
+  assert.deepEqual(extractTaskTrailers(null), []);
+  assert.deepEqual(extractTaskTrailers(''), []);
+});
+
+// --- Never-act-on-ambiguous rule ---
+
+test('extractClosingRefs: does NOT match bare "#42" without closing keyword', () => {
+  const refs = extractClosingRefs('Related to #42');
+  assert.equal(refs.length, 0);
+});
+
+test('extractClosingRefs: does NOT match "Closed #42" (past tense without s)', () => {
+  const refs = extractClosingRefs('Closed #42');
+  assert.equal(refs.length, 1, '"Closed" is a valid GitHub closing keyword');
+});
+
+test('extractTaskTrailers: does NOT match "Tasks: 42" (plural)', () => {
+  const refs = extractTaskTrailers('Tasks: 42');
+  assert.equal(refs.length, 0);
+});
+
+// --- Graceful gh absence ---
+
+test('SessionEnd exits 0 when gh is not available (graceful skip)', () => {
+  const { root } = makeFixture({ tracker: 'github' });
+  try {
+    const result = runHookProcess('end', {
+      cwd: root,
+      env: { PATH: '/nonexistent' },
+    });
+    assert.equal(result.exitCode, 0);
+  } finally { cleanup(root); }
+});
+
+test('SessionStart exits 0 when gh is not available (graceful skip)', () => {
+  const { root } = makeFixture({ tracker: 'github' });
+  try {
+    const result = runHookProcess('start', {
+      cwd: root,
+      env: { PATH: '/nonexistent' },
+    });
+    assert.equal(result.exitCode, 0);
+  } finally { cleanup(root); }
+});
+
+// --- Default argv handling ---
+
+test('defaults to start phase when no argv[2] provided', () => {
+  const { root } = makeFixture({ tracker: 'local' });
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [HOOK],
+      {
+        input: JSON.stringify({}),
+        encoding: 'utf8',
+        cwd: root,
+        timeout: 15000,
+      }
+    );
+    assert.equal(result.status, 0);
+  } finally { cleanup(root); }
+});

--- a/hooks/pre-compact.js
+++ b/hooks/pre-compact.js
@@ -25,7 +25,7 @@ function timestamp() {
 
 runHook('pre-compact', async () => {
   const root = projectRoot();
-  const tasksFile = path.join(root, 'tasks', 'todo.md');
+  const notesFile = path.join(root, 'tasks', 'notes.md');
 
   // Read tracker from manifest
   let tracker = null;
@@ -47,16 +47,18 @@ runHook('pre-compact', async () => {
     resumeSteps.unshift('- Re-read tasks/lessons.md before writing any code');
   }
 
-  if (fs.existsSync(tasksFile)) {
-    const marker = [
-      '',
-      `## ⚠️ CONTEXT COMPACTED AT ${timestamp()}`,
-      'Claude Code compacted the context window. If you are resuming after this point:',
-      ...resumeSteps,
-      '',
-    ].join('\n');
-    try { fs.appendFileSync(tasksFile, marker); } catch { /* best-effort */ }
-  }
+  // Breadcrumb goes to notes.md (D12: session narrative → notes.md), NOT todo.md
+  // (D9: nothing hand-writes todo.md — it is a generated dashboard).
+  const notesDir = path.dirname(notesFile);
+  try { fs.mkdirSync(notesDir, { recursive: true }); } catch { /* exists */ }
+  const marker = [
+    '',
+    `## ⚠️ CONTEXT COMPACTED AT ${timestamp()}`,
+    'Claude Code compacted the context window. If you are resuming after this point:',
+    ...resumeSteps,
+    '',
+  ].join('\n');
+  try { fs.appendFileSync(notesFile, marker); } catch { /* best-effort */ }
 
   const trackerNote = tracker
     ? ` Check the ${tracker} tracker for current task state.`
@@ -65,10 +67,10 @@ runHook('pre-compact', async () => {
   injectContext(
     'PreCompact',
     '⚠️ CONTEXT IS ABOUT TO BE COMPACTED. Before compaction proceeds, you must: ' +
-    '(1) Update tasks/todo.md with exactly which task you are currently in the middle of — be specific ' +
+    '(1) Update tasks/notes.md with exactly which task you are currently in the middle of — be specific ' +
     '(file, action, what is done, what is not done yet). (2) Write the current git status (any uncommitted changes). ' +
     '(3) Note any test results or errors seen.' + trackerNote +
-    ' A timestamp marker has already been appended to todo.md. ' +
+    ' A timestamp marker has already been appended to notes.md. ' +
     'Add the in-progress detail now.'
   );
 });

--- a/hooks/tracker-sync.js
+++ b/hooks/tracker-sync.js
@@ -1,0 +1,285 @@
+#!/usr/bin/env node
+// @ts-check
+// SessionStart + SessionEnd hook — tracker sync sweep (D19).
+//
+// SessionStart: reports drift (open items that look delivered) and injects
+// a context hint. Also notices todo-manual-backup.md (D23).
+//
+// SessionEnd: mechanically closes items with explicit written evidence
+// (merged PRs with closing keywords or Task: trailers). Ambiguous evidence
+// is NEVER auto-acted on (D20). Regenerates the mirror in both mode.
+//
+// Invocation context is determined by argv: the installer wires this script
+// into both SessionStart and SessionEnd hook groups. The hook reads
+// process.argv[2] to distinguish ('start' vs 'end').
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync, spawnSync } = require('node:child_process');
+const { readStdinJson, injectContext, ok, runHook } = require('./lib/hook-io');
+
+function git(args) {
+  try { return execFileSync('git', args, { encoding: 'utf8' }).trim(); }
+  catch { return ''; }
+}
+
+function readManifest(projectRoot) {
+  try {
+    const p = path.join(projectRoot, '.claude', '.harness-manifest.json');
+    if (fs.existsSync(p)) return JSON.parse(fs.readFileSync(p, 'utf8'));
+  } catch { /* fail-open */ }
+  return null;
+}
+
+function deriveMode(manifest) {
+  if (!manifest) return null;
+  const tracker = manifest.tracker;
+  if (!tracker) return null;
+  if (tracker === 'local') return 'local';
+  if (manifest.trackerMirror) return 'both';
+  return 'tracker';
+}
+
+function ghAvailable() {
+  try {
+    execFileSync('gh', ['--version'], { encoding: 'utf8', timeout: 1500, stdio: 'ignore' });
+    return true;
+  } catch { return false; }
+}
+
+function fetchMergedPRs() {
+  try {
+    const raw = execFileSync('gh', [
+      'pr', 'list', '--state', 'merged', '--limit', '50',
+      '--json', 'number,title,body,mergedAt',
+    ], { encoding: 'utf8', timeout: 5000, stdio: ['ignore', 'pipe', 'ignore'] });
+    return JSON.parse(raw);
+  } catch { return []; }
+}
+
+function listOpenItems(projectRoot) {
+  const script = path.join(projectRoot, '.claude', 'trackers', 'active', 'list-issues.sh');
+  try {
+    const raw = execFileSync('bash', [script], {
+      encoding: 'utf8', timeout: 5000,
+      cwd: projectRoot,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    return JSON.parse(raw);
+  } catch { return []; }
+}
+
+function closeItem(projectRoot, id, reason) {
+  const script = path.join(projectRoot, '.claude', 'trackers', 'active', 'close-issue.sh');
+  const args = [script, String(id)];
+  if (reason) args.push(reason);
+  const result = spawnSync('bash', args, {
+    encoding: 'utf8', timeout: 10000,
+    cwd: projectRoot,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  return result.status === 0;
+}
+
+function regenerateMirror(projectRoot) {
+  const renderScript = path.join(projectRoot, '.claude', 'trackers', 'lib', 'render-todo.sh');
+  const listScript = path.join(projectRoot, '.claude', 'trackers', 'active', 'list-issues.sh');
+  if (!fs.existsSync(renderScript)) return;
+
+  const issuesDir = path.join(projectRoot, 'tasks', 'issues');
+  if (fs.existsSync(issuesDir)) {
+    spawnSync('bash', [renderScript, issuesDir], {
+      cwd: projectRoot, timeout: 10000, stdio: 'ignore',
+    });
+    return;
+  }
+
+  if (!fs.existsSync(listScript)) return;
+
+  try {
+    const raw = execFileSync('bash', [listScript], {
+      encoding: 'utf8', timeout: 5000, cwd: projectRoot,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    const items = JSON.parse(raw);
+    if (!Array.isArray(items)) return;
+
+    const tmpDir = fs.mkdtempSync(path.join(require('node:os').tmpdir(), 'mirror-'));
+    try {
+      for (const item of items) {
+        const id = item.id || item.number;
+        if (!id) continue;
+        const lines = [
+          `id: ${id}`,
+          `title: ${item.title || ''}`,
+          `state: open`,
+          `labels: [${(item.labels || []).join(', ')}]`,
+        ];
+        fs.writeFileSync(path.join(tmpDir, `${id}.md`), lines.join('\n') + '\n');
+      }
+      spawnSync('bash', [renderScript, tmpDir], {
+        cwd: projectRoot, timeout: 10000, stdio: 'ignore',
+      });
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  } catch { /* best-effort */ }
+}
+
+// --- Evidence extraction ---
+
+// GitHub/ADO closing keywords in PR bodies (D21): "Closes #123", "Fixes AB#204"
+function extractClosingRefs(prBody) {
+  if (!prBody) return [];
+  const refs = [];
+  const ghPattern = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
+  let m;
+  while ((m = ghPattern.exec(prBody)) !== null) {
+    refs.push({ type: 'github', id: m[1] });
+  }
+  const adoPattern = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+AB#(\d+)/gi;
+  while ((m = adoPattern.exec(prBody)) !== null) {
+    refs.push({ type: 'ado', id: m[1] });
+  }
+  return refs;
+}
+
+// Local-mode trailers: anchored "Task: 42" lines in PR body (D21)
+function extractTaskTrailers(prBody) {
+  if (!prBody) return [];
+  const refs = [];
+  const lines = prBody.split('\n');
+  for (const line of lines) {
+    const m = line.match(/^Task: (\d+)$/);
+    if (m) refs.push({ type: 'local', id: m[1] });
+  }
+  return refs;
+}
+
+// --- SessionStart ---
+
+function sessionStart(projectRoot, manifest, mode) {
+  const hints = [];
+
+  // Backup notice (D23)
+  const backupPath = path.join(projectRoot, 'tasks', 'todo-manual-backup.md');
+  if (fs.existsSync(backupPath)) {
+    hints.push('Found todo-manual-backup.md from the mode migration — run /sync-tracker --import-backup to convert its unchecked items into tasks.');
+  }
+
+  // Regenerate mirror at SessionStart so session-start read is current (both mode)
+  if (mode === 'both') {
+    regenerateMirror(projectRoot);
+  }
+
+  // Drift scan: find items that look delivered but are still open
+  const openItems = listOpenItems(projectRoot);
+  if (!openItems.length) {
+    if (hints.length) {
+      injectContext('SessionStart', hints.join('\n'));
+      return;
+    }
+    return ok();
+  }
+
+  const openIds = new Set(openItems.map(i => String(i.id || i.number)));
+  const driftIds = [];
+
+  if (ghAvailable()) {
+    const prs = fetchMergedPRs();
+    for (const pr of prs) {
+      const body = (pr.body || '') + '\n' + (pr.title || '');
+      const closingRefs = mode === 'local'
+        ? extractTaskTrailers(pr.body || '')
+        : extractClosingRefs(body);
+      for (const ref of closingRefs) {
+        if (openIds.has(ref.id) && !driftIds.includes(ref.id)) {
+          driftIds.push(ref.id);
+        }
+      }
+    }
+  }
+
+  if (driftIds.length) {
+    const ids = driftIds.map(id => `#${id}`).join(', ');
+    hints.push(`Tracker sync: ${driftIds.length} item${driftIds.length === 1 ? '' : 's'} look${driftIds.length === 1 ? 's' : ''} delivered but ${driftIds.length === 1 ? 'is' : 'are'} still open (${ids}) — run /sync-tracker to reconcile.`);
+  }
+
+  if (hints.length) {
+    injectContext('SessionStart', hints.join('\n'));
+  } else {
+    ok();
+  }
+}
+
+// --- SessionEnd ---
+
+function sessionEnd(projectRoot, manifest, mode) {
+  if (!ghAvailable()) return ok();
+
+  const prs = fetchMergedPRs();
+  if (!prs.length) return ok();
+
+  const openItems = listOpenItems(projectRoot);
+  if (!openItems.length) return ok();
+
+  const openIds = new Set(openItems.map(i => String(i.id || i.number)));
+  let closedCount = 0;
+  const skipped = [];
+
+  for (const pr of prs) {
+    const body = pr.body || '';
+
+    // Extract evidence based on mode
+    let refs;
+    if (mode === 'local') {
+      refs = extractTaskTrailers(body);
+    } else {
+      refs = extractClosingRefs(body + '\n' + (pr.title || ''));
+    }
+
+    for (const ref of refs) {
+      if (!openIds.has(ref.id)) continue;
+      const success = closeItem(projectRoot, ref.id, `Delivered in PR #${pr.number}`);
+      if (success) {
+        closedCount++;
+        openIds.delete(ref.id);
+      }
+    }
+  }
+
+  // Log ambiguous evidence that was NOT acted on
+  if (skipped.length) {
+    process.stderr.write(JSON.stringify({
+      hook: 'tracker-sync',
+      phase: 'session-end',
+      skipped_ambiguous: skipped,
+    }) + '\n');
+  }
+
+  // Mirror regeneration (both mode only, D18)
+  if (mode === 'both' && closedCount > 0) {
+    regenerateMirror(projectRoot);
+  }
+
+  ok();
+}
+
+// --- Main ---
+
+const phase = process.argv[2] || 'start';
+
+runHook('tracker-sync', async () => {
+  await readStdinJson();
+  const projectRoot = git(['rev-parse', '--show-toplevel']) || process.cwd();
+  const manifest = readManifest(projectRoot);
+  const mode = deriveMode(manifest);
+
+  if (!mode) return ok();
+
+  if (phase === 'end') {
+    sessionEnd(projectRoot, manifest, mode);
+  } else {
+    sessionStart(projectRoot, manifest, mode);
+  }
+});

--- a/install/__tests__/substitute.test.js
+++ b/install/__tests__/substitute.test.js
@@ -202,7 +202,8 @@ test('buildSettings_SessionStart_IncludesStartMsgAndRouterAndContext', () => {
   assert.ok(cmds.includes('node "/h/session-start-msg.js"'), 'session-start-msg hook present');
   assert.ok(cmds.includes('node "/h/session-context.js"'), 'session-context hook preserved');
   assert.ok(cmds.includes('node "/h/session-router.js"'), 'session-router wired');
-  assert.equal(cmds.length, 3);
+  assert.ok(cmds.includes('node "/h/tracker-sync.js" start'), 'tracker-sync start wired');
+  assert.equal(cmds.length, 4);
 });
 
 test('buildSettings_SerializesToValidJson', () => {
@@ -325,10 +326,11 @@ test('reconcileSettings_UpgradesFromSingleSessionStartToFull', () => {
   const newHarness = buildSettings({ hooksUnix: '/h', sessionStartMsg: 'hi', workRoot: '', isGlobal: false });
   const result = reconcileSettings(existing, newHarness);
   const sessionHooks = result.hooks.SessionStart[0].hooks;
-  assert.equal(sessionHooks.length, 3, 'upgraded to 3 SessionStart hooks');
+  assert.equal(sessionHooks.length, 4, 'upgraded to 4 SessionStart hooks');
   assert.ok(sessionHooks.some(h => h.command.includes('session-start-msg.js')));
   assert.ok(sessionHooks.some(h => h.command.includes('session-context.js')));
   assert.ok(sessionHooks.some(h => h.command.includes('session-router.js')));
+  assert.ok(sessionHooks.some(h => h.command.includes('tracker-sync.js')));
 });
 
 test('reconcileSettings_PreservesUserHooksOnDifferentMatcher', () => {

--- a/install/lib/substitution.js
+++ b/install/lib/substitution.js
@@ -81,8 +81,12 @@ function buildSettings({ hooksUnix, sessionStartMsg: _sessionStartMsg, workRoot,
         { type: 'command', command: nodeCmd('session-start-msg.js') },
         { type: 'command', command: nodeCmd('session-context.js') },
         { type: 'command', command: nodeCmd('session-router.js') },
+        { type: 'command', command: nodeCmd('tracker-sync.js') + ' start' },
       ] }],
-      SessionEnd: [{ matcher: '*', hooks: [{ type: 'command', command: nodeCmd('session-log.js') }] }],
+      SessionEnd: [{ matcher: '*', hooks: [
+        { type: 'command', command: nodeCmd('session-log.js') },
+        { type: 'command', command: nodeCmd('tracker-sync.js') + ' end' },
+      ] }],
     },
   };
   if (isGlobal && workRoot) {

--- a/install/lib/updater.js
+++ b/install/lib/updater.js
@@ -22,6 +22,7 @@ const HARNESS_HOOK_SCRIPTS = new Set([
   'session-context.js',
   'session-router.js',
   'session-log.js',
+  'tracker-sync.js',
 ]);
 
 const ENTERPRISE_ONLY_AGENTS = new Set([

--- a/skills/sync-tracker/SKILL.md
+++ b/skills/sync-tracker/SKILL.md
@@ -1,51 +1,69 @@
 ---
 name: sync-tracker
-description: Reconcile merged PRs and completed work against open tracker items. Closes issues/tasks in GitHub, Todoist, or ADO that have been delivered. Usage: /sync-tracker [--dry-run]
-argument-hint: --dry-run
+description: "Reconcile merged PRs and completed work against open tracker items. Mode-aware: works in local, tracker, and both modes. Supports --dry-run and --import-backup [file]. Usage: /sync-tracker [--dry-run] [--import-backup [file]]"
+argument-hint: "--dry-run | --import-backup [file]"
 ---
 
-**Core Philosophy:** Tracker items that have been delivered (PR merged) should be closed automatically. This skill bridges the gap between local completion state and external tracker state.
+**Core Philosophy:** Tracker items that have been delivered (PR merged) should be closed. This skill is the interactive judgment layer the sweep hook (`hooks/tracker-sync.js`) points at — the sweep handles explicit evidence mechanically; this skill handles ambiguous evidence with user confirmation.
 
-**Triggers:** "sync tracker", "close completed issues", "update tracker", "reconcile PRs", "clean up tracker"
+**Triggers:** "sync tracker", "close completed issues", "update tracker", "reconcile PRs", "clean up tracker", "import backup"
 
 ---
 
-You are the tracker synchronization agent. Your job is to find tracker items that have been delivered but are still open, and close them.
+You are the tracker synchronization agent. Your job is to find tracker items that have been delivered but are still open, and close them. You are mode-aware: behavior adapts to local, tracker, or both mode.
 
 Parse `$ARGUMENTS`:
 - `--dry-run` → report what would be closed, but don't actually close anything.
+- `--import-backup [file]` → import mode (D23): convert unchecked items from a backup file into tracker tasks. Default source: `tasks/todo-manual-backup.md`. Also accepts `tasks/plan.md` as a source (D29).
 
 ---
 
-## Step 1 — Detect active tracker
+## Step 1 — Detect mode
 
-Read `.claude/.harness-manifest.json` → `tracker` field to determine the active tracker type (GitHub, Todoist, or ADO). If not set, fall back to `tasks/tracker-config.md` `**Type:**` field or adapter script detection in `.claude/trackers/active/`.
+Read `.claude/.harness-manifest.json`:
+- `tracker` field → the active tracker type (`github`, `todoist`, `ado`, `local`).
+- `trackerMirror` field → whether mirror mode is active.
+- Derive the mode:
+  - `tracker === 'local'` → **local mode**
+  - External tracker + `trackerMirror === true` → **both mode**
+  - External tracker + no mirror → **tracker mode**
 
-Note the tracker type for Step 3.
+If no manifest or no tracker configured, fall back to `tasks/tracker-config.md` `**Type:**` field or adapter script detection in `.claude/trackers/active/`.
+
+Note the mode for subsequent steps.
 
 ---
 
-## Step 2 — Find delivered items
+## Step 2 — Route by argument
 
-Gather evidence of completed work from multiple sources. Run these in parallel:
+If `--import-backup` was passed, jump to **Step 7 (Import backup)**.
+
+Otherwise, continue to Step 3.
+
+---
+
+## Step 3 — Find delivered items
+
+Gather evidence of completed work. **`todo.md` is NEVER an evidence source** — it is a generated dashboard (D9). Evidence comes from PRs and sprint tables only.
 
 **Source A — Merged PRs:**
 ```bash
 gh pr list --state merged --limit 50 --json number,title,body,mergedAt
 ```
-Extract issue/task references from PR titles and bodies. Look for patterns like `#123`, `Fixes #123`, `Closes #123`, or Todoist task IDs.
+Extract references based on mode:
+- **Local mode:** look for anchored `Task: <N>` trailer lines in PR bodies (one per line, `^Task: \d+$`). Never match prose like "builds on task 42".
+- **Tracker/both mode:** look for GitHub closing keywords (`Closes #123`, `Fixes #123`, `Resolves #123`) and ADO references (`Fixes AB#204`). Also check PR titles.
 
-**Source B — Local todo.md:**
-Read `tasks/todo.md`. Find all items marked ✅ that reference a tracker ID (issue number, task ID, or work item ID).
+Skip gracefully if `gh` is not available or not authenticated.
 
-**Source C — Sprint files:**
-Glob `tasks/sprint*.md` and read the latest. Find rows in the Master Status Table where the PR column shows a merged PR URL or "Merged" status.
+**Source B — Sprint files (ambiguous — flag only):**
+Glob `tasks/sprint*.md` and read the latest. Find rows in the Master Status Table where the Status column shows "Done" but no merged PR is referenced. These are **ambiguous** — flag them for manual review but do NOT auto-close (D20).
 
 Collect all unique tracker IDs that appear to be delivered.
 
 ---
 
-## Step 3 — Check tracker state
+## Step 4 — Check tracker state
 
 For each candidate ID, call the active tracker adapter to check current state:
 
@@ -57,37 +75,40 @@ Parse the output to determine if the item is already closed/completed. Filter do
 
 ---
 
-## Step 4 — Report
+## Step 5 — Report
 
 Show a summary table:
 
 | ID | Title | Evidence | Current State | Action |
 |---|---|---|---|---|
-| #123 | Fix login bug | PR #45 merged | Open | Close |
-| #456 | Add dark mode | todo.md ✅ | Already closed | Skip |
+| #123 | Fix login bug | PR #45 merged (Closes #123) | Open | Close |
+| #456 | Add dark mode | Sprint table "Done" (no PR) | Open | ⚠ Ambiguous — needs confirmation |
+| #789 | Refactor auth | PR #67 merged | Already closed | Skip |
 
 If `--dry-run` was passed, stop here with:
 
 ---
-**Dry run complete.** [N] tracker items would be closed. Run `/sync-tracker` (without --dry-run) to close them.
+**Dry run complete.** [N] items have explicit delivery evidence and would be closed. [M] items have ambiguous evidence and need manual confirmation. Run `/sync-tracker` (without --dry-run) to close them.
 
 ---
 
 ---
 
-## Step 5 — Close delivered items
+## Step 6 — Close delivered items
 
-For each item that is still open and has delivery evidence:
-
+**Explicit evidence items:** close without asking:
 ```bash
-bash .claude/trackers/active/close-issue.sh <ID>
+bash .claude/trackers/active/close-issue.sh <ID> "Delivered in PR #<N>"
 ```
+
+**Ambiguous evidence items:** ask the user for confirmation on each one before closing.
 
 Report each closure result.
 
----
-
-## Step 6 — Summary
+**Both mode — regenerate mirror:** after closing items, regenerate `tasks/todo.md`:
+```bash
+bash .claude/trackers/lib/render-todo.sh tasks/issues
+```
 
 Output:
 
@@ -96,8 +117,55 @@ Output:
 
 ---
 
+---
+
+## Step 7 — Import backup (`--import-backup`)
+
+This flow serves the mode migration (D23) and mode switches (D25).
+
+**7a.** Determine source file:
+- If a file path was given after `--import-backup`, use that.
+- Default: `tasks/todo-manual-backup.md`.
+- Also accept `tasks/plan.md` (D29: retired solo plan).
+
+Read the source file. If it doesn't exist, stop with a clear message.
+
+**7b.** Parse the file for unchecked items. Look for markdown list items that are NOT checked:
+- `- [ ] ...` or `- ...` (plain bullets) → candidate items
+- `- [x] ...` or `- [X] ...` → skip (already done)
+
+Extract a title for each candidate item.
+
+**7c.** Cross-check each candidate against open items in the active backend:
+```bash
+bash .claude/trackers/active/list-issues.sh
+```
+
+Flag items that look like duplicates of existing open items.
+
+**7d.** Present the full list to the user. For each candidate, show:
+- The original text from the backup
+- Whether it looks like a duplicate
+- Ask: **Create this as a new task? (yes/skip)**
+
+**7e.** For each approved item, create it:
+```bash
+bash .claude/trackers/active/create-issue.sh "<title>" "<body>" ""
+```
+
+**7f.** Summary:
+---
+**Import complete.** Created [N] tasks from [source file]. [M] items skipped. The source file has NOT been deleted — review it and delete manually when satisfied.
+
+---
+
+Never delete the source file — tell the user to do it when done.
+
+---
+
 ## Error handling
 
-- If `close-issue.sh` fails for an item, log the error and continue with the remaining items. Report failures at the end.
+- If `close-issue.sh` or `create-issue.sh` fails for an item, log the error and continue with the remaining items. Report failures at the end.
 - If the tracker adapter is not installed, stop with a clear message: "No tracker adapter found. Run the installer to configure a tracker."
 - If no delivered items are found, say so and exit cleanly.
+- If `gh` is not available, skip PR evidence gathering and note it in the report.


### PR DESCRIPTION
## Summary

- **New `hooks/tracker-sync.js`** — SessionStart/SessionEnd sweep hook that reports drift (open items with merged-PR evidence) and mechanically closes delivered items using explicit written evidence only (D19/D20/D21). Ambiguous evidence is never auto-acted on. Mirror regenerated in both mode via the shared renderer (D17/D18).
- **Fixed `pre-compact.js`** — breadcrumb moved from `tasks/todo.md` to `tasks/notes.md`, resolving the D9 violation (todo.md is a generated dashboard; session narrative belongs in notes.md per D12).
- **Reworked `/sync-tracker` skill** — fully mode-aware (local/tracker/both), todo.md removed as evidence source (D9), new `--import-backup [file]` mode for the D23/D25 migration and mode-switch flow.
- **Pipeline check** — confirmed `story-pr-agent` Step 7 calls `close-issue.sh` at delivery; no gaps found.
- **Wiring** — `tracker-sync.js` added to `buildSettings()` (SessionStart + SessionEnd), `HARNESS_HOOK_SCRIPTS`, and `examples/settings.json`. Test count assertions updated.
- 341 tests pass, 0 lint errors. 27 new tracker-sync tests covering mode gating, evidence parsing (anchored matching), graceful `gh` absence, and backup notices.

## Test plan

- [ ] `npm test` passes (341 tests, 0 failures)
- [ ] `npm run lint` clean
- [ ] Verify tracker-sync.js exits 0 (no-op) when manifest is missing or tracker is null
- [ ] Verify `extractClosingRefs` matches `Closes #N`, `Fixes AB#N` but not bare `#N`
- [ ] Verify `extractTaskTrailers` matches anchored `Task: 42` but NOT prose "builds on task 42"
- [ ] Verify pre-compact.js now writes to notes.md, not todo.md
- [ ] Review: no scope creep into WS5 territory (skill consumers, drift-check invariants)