### PR TITLE
chore: add dogfood dev loop (symlink .claude to repo-root source)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,24 @@ htmlcov/
 *.env.local
 local.settings.json
 appsettings.Development.json
+
+# >>> claude-code-harness managed — do not edit inside this block >>>
+tasks/issues/
+tasks/todo.md
+tasks/lessons.md
+tasks/pr-queue.md
+tasks/flags-and-notes.md
+tasks/people.md
+tasks/admin.md
+tasks/tracker-config.md
+tasks/sprint*.md
+tasks/stories/
+tasks/sessions*.jsonl*
+tasks/metrics*.jsonl*
+# <<< claude-code-harness managed <<<
+
+# Dogfood install: harness installed onto itself for local use.
+# Source of truth is skills/ agents/ hooks/ rules/ at repo root; .claude/ holds
+# personalized, placeholder-substituted copies — build artifacts, never commit.
+.claude/
+tasks/notes.md

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "description": "Dev-only manifest for tests and lint. Not copied by the installer; runtime stays zero-dep.",
   "scripts": {
+    "dogfood": "node scripts/dogfood.js",
     "test": "node --test hooks/__tests__/*.test.js trackers/__tests__/*.test.js code-platform/__tests__/*.test.js install/__tests__/*.test.js",
     "test:hooks": "node --test hooks/__tests__/*.test.js",
     "test:trackers": "node --test trackers/__tests__/*.test.js",

--- a/scripts/dogfood.js
+++ b/scripts/dogfood.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+'use strict';
+
+// Dogfood link: make this repo's own .claude/ point at the repo-root source via
+// symlinks, so editing source IS editing the live harness — no copy, no sync
+// step, no watcher. Run ONCE after a fresh clone (or if .claude/ dirs ever got
+// replaced with real copies). Day-to-day you never run anything: edit source,
+// restart Claude Code, and your changes are already live.
+//
+//   npm run dogfood
+//
+// Prerequisite: a base install must have created .claude/settings.json + manifest
+// (node install/install.js --project . --yes --name '…' --project-name '…').
+// This script only converts the skills/agents/hooks/rules dirs into symlinks.
+
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const claudeDir = path.join(repoRoot, '.claude');
+const LINKED = ['skills', 'agents', 'hooks', 'rules'];
+
+if (!fs.existsSync(path.join(claudeDir, 'settings.json'))) {
+  console.error(
+    '  No base install found (.claude/settings.json missing).\n' +
+    '  Run the installer once first:\n' +
+    "    node install/install.js --project . --yes --name 'Your Name' --project-name 'claude-code-harness'\n" +
+    '  then re-run: npm run dogfood'
+  );
+  process.exit(1);
+}
+
+let changed = 0;
+for (const name of LINKED) {
+  const linkPath = path.join(claudeDir, name);
+  const target = path.join('..', name); // relative: .claude/<name> -> ../<name>
+  const sourceDir = path.join(repoRoot, name);
+
+  if (!fs.existsSync(sourceDir)) {
+    console.error(`  Source dir missing: ${name}/ — skipping.`);
+    continue;
+  }
+
+  // Already the correct symlink? leave it.
+  try {
+    if (fs.lstatSync(linkPath).isSymbolicLink() && fs.readlinkSync(linkPath) === target) {
+      continue;
+    }
+  } catch {
+    /* linkPath doesn't exist yet — fall through to create it */
+  }
+
+  fs.rmSync(linkPath, { recursive: true, force: true });
+  fs.symlinkSync(target, linkPath);
+  console.log(`  linked .claude/${name} -> ${target}`);
+  changed++;
+}
+
+console.log(
+  changed === 0
+    ? '  Already in dogfood link mode — source is the live harness. Nothing to do.'
+    : '\n  Dogfood link mode set. Editing source now updates the live harness directly.\n' +
+      '  Restart Claude Code to load changes (a running session cannot reload its own harness).'
+);


### PR DESCRIPTION
## Summary

Sets up the harness to develop itself — the harness is installed onto its own repo so its skills/agents/hooks are live while working in this repo.

`.claude/{skills,agents,hooks,rules}` are **symlinked** to the repo-root source, so editing source updates the live harness directly — no copy step, no watcher, no per-edit command. `.claude/` is gitignored (personalized/build artifacts; the source of truth stays at repo root).

## Changes

- **.gitignore** — ignore `.claude/` and `tasks/notes.md` (personalized install artifacts, never committed)
- **scripts/dogfood.js** — one-time idempotent linker; recreates the `.claude/` symlinks after a fresh clone (or if the dirs ever became real copies). Not a per-edit step.
- **package.json** — `npm run dogfood`

## Dev loop

Edit source → close session → open a new session → the improved harness is live → use it to improve further. The only manual step is the session restart, which is a Claude Code limitation (it reads its harness at session start) and is absorbed naturally into starting the next task.

## Notes

- Trade-off: symlinked skills show literal `YOUR_NAME`/`YOUR_PROJECT_NAME` (no substitution) — cosmetic, and arguably better since you test the exact template shipped to users.
- Footgun: do not re-run the installer against `.` — it replaces the symlinks with real copies. `npm run dogfood` re-links if that happens.

## Test plan

- [ ] `npm run dogfood` on a fresh clone recreates the four symlinks
- [ ] `git status` stays clean of `.claude/` (only tracked change is source)
- [ ] Harness skills load in a new session in this repo