### PR TITLE
fix(todoist): make adapter compatible with td v1.74

### DIFF
--- a/trackers/todoist/create-issue.sh
+++ b/trackers/todoist/create-issue.sh
@@ -31,7 +31,7 @@ check_auth_todoist
 # Auto-read project from config when not passed as argument
 if [ -z "$PROJECT" ]; then
   if [ -f "tasks/tracker-config.md" ]; then
-    _proj=$(grep -i "todoist_project\s*=" tasks/tracker-config.md | sed 's/.*=\s*//' | tr -d ' \r\n')
+    _proj=$(grep -i "todoist_project[[:space:]]*=" tasks/tracker-config.md | sed 's/.*=[[:space:]]*//; s/[[:space:]]*$//' | tr -d '\r')
     [ -n "$_proj" ] && [ "$_proj" != "YOUR_TODOIST_PROJECT" ] && PROJECT="$_proj"
   fi
   if [ -z "$PROJECT" ] && [ -f "tasks/notes.md" ]; then

--- a/trackers/todoist/get-issue-children.sh
+++ b/trackers/todoist/get-issue-children.sh
@@ -24,7 +24,9 @@ source "$(dirname "$0")/../lib/retry.sh"
 source "$(dirname "$0")/../lib/auth-check.sh"
 check_auth_todoist
 
-CHILDREN=$(with_retry "$TD" task list --parent "$TASK_ID" --json)
+# `td task list` returns only active (open) tasks; completed children simply
+# do not appear. So every child returned here is OPEN.
+CHILDREN=$(with_retry "$TD" task list --parent "$TASK_ID" --json | jq '(.results // .)')
 
 TOTAL=$(echo "$CHILDREN" | jq 'length' 2>/dev/null)
 
@@ -32,11 +34,9 @@ if [ "$TOTAL" -gt 0 ] 2>/dev/null; then
   echo "# Sub-tasks for Task $TASK_ID"
   echo ""
   echo "$CHILDREN" | jq -r '.[] |
-    "- [" + (if .is_completed then "x" else " " end) + "] " + (.id|tostring) + " " + .content + " (" + (if .is_completed then "CLOSED" else "OPEN" end) + ")"'
+    "- [ ] " + (.id|tostring) + " " + .content + " (OPEN)"'
   echo ""
-  OPEN=$(echo "$CHILDREN" | jq '[.[] | select(.is_completed == false)] | length')
-  CLOSED=$(echo "$CHILDREN" | jq '[.[] | select(.is_completed == true)] | length')
-  echo "_Progress: $CLOSED/$TOTAL complete ($OPEN open)_"
+  echo "_Progress: $TOTAL open (completed sub-tasks are not listed by Todoist)_"
 else
   echo "# Sub-tasks for Task $TASK_ID"
   echo ""

--- a/trackers/todoist/get-sprint-issues.sh
+++ b/trackers/todoist/get-sprint-issues.sh
@@ -25,7 +25,7 @@ check_auth_todoist
 TODOIST_PROJECT=""
 
 if [ -f "tasks/tracker-config.md" ]; then
-  _proj=$(grep -i "todoist_project\s*=" tasks/tracker-config.md | sed 's/.*=\s*//' | tr -d ' \r\n')
+  _proj=$(grep -i "todoist_project[[:space:]]*=" tasks/tracker-config.md | sed 's/.*=[[:space:]]*//; s/[[:space:]]*$//' | tr -d '\r')
   [ -n "$_proj" ] && [ "$_proj" != "YOUR_TODOIST_PROJECT" ] && TODOIST_PROJECT="$_proj"
 fi
 
@@ -35,14 +35,23 @@ if [ -z "$TODOIST_PROJECT" ] && [ -f "tasks/notes.md" ]; then
   [ -n "$_proj" ] && TODOIST_PROJECT="$_proj"
 fi
 
-LIST_ARGS=(task list --json)
+# Fall back to the configured default section when none is passed.
+if [ -z "$SECTION" ] && [ -f "tasks/tracker-config.md" ]; then
+  SECTION=$(grep -i "todoist_default_section[[:space:]]*=" tasks/tracker-config.md | sed 's/.*=[[:space:]]*//; s/[[:space:]]*$//' | tr -d '\r')
+fi
 
+# `td task list` (v1.74+) has no --section flag; resolve the section name to an
+# id and filter client-side.
+SECTION_ID=""
+if [ -n "$SECTION" ] && [ -n "$TODOIST_PROJECT" ]; then
+  SECTION_ID=$(with_retry "$TD" section list --project "$TODOIST_PROJECT" --json \
+    | jq -r --arg n "$SECTION" '(.results // .)[] | select(.name==$n) | .id' | head -1)
+fi
+
+LIST_ARGS=(task list --json)
 if [ -n "$TODOIST_PROJECT" ]; then
   LIST_ARGS+=(--project "$TODOIST_PROJECT")
 fi
 
-if [ -n "$SECTION" ]; then
-  LIST_ARGS+=(--section "$SECTION")
-fi
-
-with_retry "$TD" "${LIST_ARGS[@]}"
+with_retry "$TD" "${LIST_ARGS[@]}" \
+  | jq --arg sid "$SECTION_ID" '[ (.results // .)[] | select($sid == "" or .sectionId == $sid) ]'

--- a/trackers/todoist/list-issues.sh
+++ b/trackers/todoist/list-issues.sh
@@ -1,28 +1,50 @@
 #!/bin/bash
 # list-issues.sh — Todoist adapter
 # Usage: bash .claude/trackers/active/list-issues.sh
-# Returns all open tasks in the configured project as a JSON array.
+# Returns open tasks in the configured project (scoped to the configured
+# section when set) as a JSON array.
 # Output: JSON array [{id, title, state, labels, assignees, url}]
+#
+# Config is read from tasks/tracker-config.md:
+#   todoist_project         = <project-name>
+#   todoist_default_section = <section-name>   (optional)
 
-TODOIST_PROJECT="YOUR_TODOIST_PROJECT"
-
-# Source shared libraries
 source "$(dirname "$0")/../lib/retry.sh"
 source "$(dirname "$0")/../lib/auth-check.sh"
 check_auth_todoist
 
 td="${TODOIST_CLI:-td}"
 
-if [[ "$TODOIST_PROJECT" == "YOUR_TODOIST_PROJECT" ]]; then
-  # No project configured — list all open tasks
-  RESULT=$(with_retry "$td" task list --json)
-else
-  RESULT=$(with_retry "$td" task list --project "$TODOIST_PROJECT" --json)
+# --- read scope from config (internal spaces preserved) ---
+TODOIST_PROJECT=""
+TODOIST_SECTION=""
+if [ -f "tasks/tracker-config.md" ]; then
+  _proj=$(grep -i "todoist_project[[:space:]]*=" tasks/tracker-config.md | sed 's/.*=[[:space:]]*//; s/[[:space:]]*$//' | tr -d '\r')
+  [ -n "$_proj" ] && [ "$_proj" != "YOUR_TODOIST_PROJECT" ] && TODOIST_PROJECT="$_proj"
+  _sec=$(grep -i "todoist_default_section[[:space:]]*=" tasks/tracker-config.md | sed 's/.*=[[:space:]]*//; s/[[:space:]]*$//' | tr -d '\r')
+  [ -n "$_sec" ] && TODOIST_SECTION="$_sec"
 fi
 
-if [ $? -ne 0 ]; then
+# --- resolve section name -> id (td list cannot filter by section) ---
+SECTION_ID=""
+if [ -n "$TODOIST_SECTION" ] && [ -n "$TODOIST_PROJECT" ]; then
+  SECTION_ID=$(with_retry "$td" section list --project "$TODOIST_PROJECT" --json \
+    | jq -r --arg n "$TODOIST_SECTION" '(.results // .)[] | select(.name==$n) | .id' | head -1)
+fi
+
+# --- list tasks ---
+if [ -n "$TODOIST_PROJECT" ]; then
+  RESULT=$(with_retry "$td" task list --project "$TODOIST_PROJECT" --json)
+else
+  RESULT=$(with_retry "$td" task list --json)
+fi
+
+if [ $? -ne 0 ] || [ -z "$RESULT" ]; then
   echo '{"error": "Failed to list tasks from Todoist"}' >&2
   exit 1
 fi
 
-echo "$RESULT" | jq '[.[] | {id: .id, title: .content, state: "open", labels: .labels, assignees: [], url: .url}]'
+echo "$RESULT" | jq --arg sid "$SECTION_ID" '
+  [ (.results // .)[]
+    | select($sid == "" or .sectionId == $sid)
+    | {id: .id, title: .content, state: "open", labels: (.labels // []), assignees: [], url: .url} ]'


### PR DESCRIPTION
## Summary

The Todoist tracker adapter was written against an older `td` output shape and broke against **`td` v1.74**. Surfaced while switching a project's tracker to Todoist — the read path failed immediately (`jq: Cannot index array with string "id"`) and multi-word project names matched zero tasks.

## Fixes (4 scripts)

- **Wrapped list responses** — `list-issues.sh`, `get-issue-children.sh`, `get-sprint-issues.sh` assumed a bare JSON array; `td` v1.74 now wraps list results in `{results: [...]}`. Unwrapped with `(.results // .)` (backward-compatible with the old bare-array shape).
- **Config parser stripped internal spaces** — `tr -d ' '` turned `"Build Mode"` into `"BuildMode"`, matching no tasks. Now trims only leading/trailing whitespace. Affected `create-issue.sh`, `get-sprint-issues.sh`, `list-issues.sh`.
- **`list-issues.sh` ignored config** — had a hardcoded `YOUR_TODOIST_PROJECT` placeholder. Now reads project + section from `tracker-config.md` and scopes by `sectionId` (td v1.74 dropped the `--section` flag for `list`, so it resolves the section name → id and filters client-side).
- **`get-issue-children.sh`** referenced a nonexistent `is_completed` field. `td task list` returns only active tasks, so listed children are always OPEN.

## Test plan

- [x] `list-issues.sh` returns correctly-shaped JSON scoped to project+section against live `td` v1.74
- [x] `get-issue-children.sh` lists sub-tasks of a parent
- [x] `get-blockers.sh` reads back `Blocked by:` edges
- [x] End-to-end: migrated a 9-item wayfinder map (map + 8 tickets with labels + blocker graph) into Todoist and verified the computed frontier reproduced identically
- [ ] Regression check on other backends (github/ado/local) — unchanged, not touched by this PR