### PR TITLE
fix(todoist): report real completion state in get-issue.sh

### DIFF
--- a/trackers/__tests__/conformance.test.js
+++ b/trackers/__tests__/conformance.test.js
@@ -289,6 +289,24 @@ describe('happy-path-stdout', () => {
     assert.equal(normalize(r.stdout), normalize(readGolden('todoist', 'get-issue.happy.md')));
   });
 
+  // td v1.74 `task view --json` carries no completion flag; state is derived
+  // from active-list membership. An active task reads OPEN with a real project.
+  test('todoist_GetIssue_ActiveTask_ReportsOpenWithProject', () => {
+    const r = runScript('todoist', 'get-issue.sh', ['1234']);
+    assert.equal(r.exitCode, 0, `non-zero exit: ${r.stderr}`);
+    assert.match(r.stdout, /\*\*State:\*\* OPEN/);
+    assert.match(r.stdout, /\*\*Project:\*\* 111/);
+    assert.match(r.stdout, /\*\*Section:\*\* 555/);
+  });
+
+  // 5678 is viewable but absent from the active list -> must read CLOSED.
+  test('todoist_GetIssue_CompletedTask_ReportsClosed', () => {
+    const r = runScript('todoist', 'get-issue.sh', ['5678']);
+    assert.equal(r.exitCode, 0, `non-zero exit: ${r.stderr}`);
+    assert.match(r.stdout, /\*\*State:\*\* CLOSED/);
+    assert.match(r.stdout, /\*\*Project:\*\* 111/);
+  });
+
   test('github_CloseIssue_HappyPath_ExitsZero', () => {
     const r = runScript('github', 'close-issue.sh', ['1234']);
     assert.equal(r.exitCode, 0, `non-zero exit: ${r.stderr}`);

--- a/trackers/__tests__/fixtures/bin/td
+++ b/trackers/__tests__/fixtures/bin/td
@@ -72,6 +72,11 @@ case "$1 $2" in
       cat "$fixture_dir/td-task-4321.json"
       exit 0
     fi
+    # 5678 is viewable but absent from the active task list -> completed.
+    if [ "$ref" = "5678" ]; then
+      cat "$fixture_dir/td-task-5678.json"
+      exit 0
+    fi
     cat "$fixture_dir/td-task-1234.json"
     exit 0
     ;;

--- a/trackers/__tests__/fixtures/responses/td-task-1234.json
+++ b/trackers/__tests__/fixtures/responses/td-task-1234.json
@@ -4,9 +4,13 @@
   "description": "Users need to be able to log in.\n\n## Acceptance criteria\n- Valid credentials authenticate the user\n",
   "labels": ["feature", "priority-high"],
   "priority": 3,
-  "is_completed": false,
-  "section_id": "555",
-  "project_id": "111",
-  "parent_id": null,
-  "url": "https://todoist.com/showTask?id=1234"
+  "isUncompletable": false,
+  "sectionId": "555",
+  "projectId": "111",
+  "responsibleUid": null,
+  "deadline": null,
+  "due": null,
+  "duration": null,
+  "url": "https://todoist.com/showTask?id=1234",
+  "webUrl": "https://app.todoist.com/app/task/1234"
 }

--- a/trackers/__tests__/fixtures/responses/td-task-5678.json
+++ b/trackers/__tests__/fixtures/responses/td-task-5678.json
@@ -1,0 +1,16 @@
+{
+  "id": "5678",
+  "content": "Ship the beta",
+  "description": "Already delivered.",
+  "labels": ["feature"],
+  "priority": 4,
+  "isUncompletable": false,
+  "sectionId": "555",
+  "projectId": "111",
+  "responsibleUid": null,
+  "deadline": null,
+  "due": null,
+  "duration": null,
+  "url": "https://todoist.com/showTask?id=5678",
+  "webUrl": "https://app.todoist.com/app/task/5678"
+}

--- a/trackers/__tests__/fixtures/responses/td-task-list.json
+++ b/trackers/__tests__/fixtures/responses/td-task-list.json
@@ -5,9 +5,10 @@
     "description": "Users need to be able to log in.",
     "labels": ["feature", "priority-high"],
     "priority": 3,
-    "is_completed": false,
-    "section_id": "555",
-    "project_id": "111"
+    "isUncompletable": false,
+    "sectionId": "555",
+    "projectId": "111",
+    "url": "https://todoist.com/showTask?id=1234"
   },
   {
     "id": "1235",
@@ -15,8 +16,9 @@
     "description": "Users should be able to reset their password.",
     "labels": ["feature"],
     "priority": 2,
-    "is_completed": false,
-    "section_id": "555",
-    "project_id": "111"
+    "isUncompletable": false,
+    "sectionId": "555",
+    "projectId": "111",
+    "url": "https://todoist.com/showTask?id=1235"
   }
 ]

--- a/trackers/todoist/get-issue.sh
+++ b/trackers/todoist/get-issue.sh
@@ -30,14 +30,48 @@ if [ -z "$RAW" ]; then
   exit 1
 fi
 
-echo "$RAW" | jq -r '
+# --- derive completion state (td v1.74) ---
+# `td task view --json` returns a task whether it is active or completed, and
+# carries NO completion flag (no is_completed/checked/completed_at). So derive
+# state the way list-issues.sh trusts it: a task present in `task view` but
+# ABSENT from the active task list is completed. `td task list` returns only
+# non-completed tasks — which is why list-issues.sh hardcodes state:"open".
+#
+# Read the configured project exactly like list-issues.sh does, so the active
+# query is scoped identically.
+# Edge case: a task in a DIFFERENT project than the configured one would be
+# misjudged as CLOSED. Acceptable for this harness's single-project setup.
+# TODO: prefer a global active-task query if a future td exposes one.
+TODOIST_PROJECT=""
+if [ -f "tasks/tracker-config.md" ]; then
+  _proj=$(grep -i "todoist_project[[:space:]]*=" tasks/tracker-config.md | sed 's/.*=[[:space:]]*//; s/[[:space:]]*$//' | tr -d '\r')
+  [ -n "$_proj" ] && [ "$_proj" != "YOUR_TODOIST_PROJECT" ] && TODOIST_PROJECT="$_proj"
+fi
+
+# `.results?` tolerates both td shapes: an object {results:[...]} and a bare
+# array (the `?` suppresses the array-index error so the `// .` fallback wins).
+if [ -n "$TODOIST_PROJECT" ]; then
+  ACTIVE_IDS=$(with_retry "$TD" task list --project "$TODOIST_PROJECT" --json | jq -r '(.results? // .)[].id | tostring')
+else
+  ACTIVE_IDS=$(with_retry "$TD" task list --json | jq -r '(.results? // .)[].id | tostring')
+fi
+
+if echo "$ACTIVE_IDS" | grep -qx "$TASK_ID"; then
+  STATE="OPEN"
+else
+  STATE="CLOSED"
+fi
+
+# Field names are camelCase in td v1.74 (.sectionId / .projectId); these render
+# ids, not names — matching prior behavior.
+echo "$RAW" | jq -r --arg state "$STATE" '
   "# Task " + (.id|tostring) + ": " + .content,
   "",
-  "**State:** " + (if .is_completed then "CLOSED" else "OPEN" end),
+  "**State:** " + $state,
   "**Priority:** " + (if .priority == 4 then "p1" elif .priority == 3 then "p2" elif .priority == 2 then "p3" else "p4" end),
   "**Labels:** " + (if (.labels | length) > 0 then (.labels | join(", ")) else "None" end),
-  "**Section:** " + (.section_id // "None" | tostring),
-  "**Project:** " + (.project_id // "None" | tostring),
+  "**Section:** " + (.sectionId // "None" | tostring),
+  "**Project:** " + (.projectId // "None" | tostring),
   "",
   "## Description",
   (.description // "_No description_")


### PR DESCRIPTION
## Problem

`trackers/todoist/get-issue.sh` reported **every** task as `State: OPEN` and every task's `Section`/`Project` as `None`, regardless of reality. This silently returns wrong data — it misled a wayfinder session into reading 5 already-completed tickets as open (frontier appeared empty when it wasn't).

## Root cause — two field-mapping bugs against `td` v1.74

`td task view --json` in v1.74:

1. **Has no completion field at all** — no `is_completed` / `checked` / `completed_at`. The script's `if .is_completed then "CLOSED" else "OPEN"` therefore always fell through to `OPEN`.
2. **Uses camelCase keys** — `.sectionId` / `.projectId`, not the `.section_id` / `.project_id` the script read → always `None`.

`td task view` returns a task whether it is active or completed, so it can't be used alone to determine state.

## Fix

- **Derive completion from active-list membership**, the same signal `list-issues.sh` already trusts: `td task list --project <name> --json` returns only non-completed tasks, so a task viewable but **absent** from that list is completed. Project scope is read from `tasks/tracker-config.md` exactly as `list-issues.sh` does.
- **Fix the field names** to `.sectionId` / `.projectId`.
- Documented edge case in a comment: a task in a different project than the configured one would be misjudged (acceptable for the single-project setup; TODO if a future `td` exposes a global active query).

## Tests

- Added `todoist_GetIssue_CompletedTask_ReportsClosed` — feeds a task that is viewable but absent from the active list and asserts `State: CLOSED`.
- Updated the mock `td` and response fixtures to the v1.74 payload shape (camelCase, new completed-task fixture `td-task-5678.json`).
- Full tracker suite green: **97 pass / 0 fail** (`npm run test:trackers`).

## Notes

- Separate from the existing open `close-issue.sh` issue — this is a distinct `get-issue.sh` defect.
- No behavior change for callers other than corrected `State` / `Section` / `Project` output.