### PR TITLE
chore(install): gitignore _prototype/ scratch by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ tasks/sprint*.md
 tasks/stories/
 tasks/sessions*.jsonl*
 tasks/metrics*.jsonl*
+_prototype/
 # <<< claude-code-harness managed <<<
 
 # Dogfood install: harness installed onto itself for local use.

--- a/install/__tests__/non-interactive.test.js
+++ b/install/__tests__/non-interactive.test.js
@@ -365,6 +365,7 @@ test('install.js --yes writes managed gitignore block, idempotent on re-install'
     assert.ok(content.includes('claude-code-harness managed'), 'sentinel must be present');
     assert.ok(content.includes('tasks/issues/'), 'tasks/issues/ must be in block');
     assert.ok(content.includes('tasks/todo.md'), 'tasks/todo.md must be in block');
+    assert.ok(content.includes('_prototype/'), '_prototype/ (throwaway scratch) must be in block');
 
     // Re-run: block should appear exactly once
     runInstallJs(['--yes', '--project', dir]);

--- a/install/install.js
+++ b/install/install.js
@@ -153,6 +153,9 @@ const MANAGED_GITIGNORE_ENTRIES = [
   'tasks/stories/',
   'tasks/sessions*.jsonl*',
   'tasks/metrics*.jsonl*',
+  // Throwaway prototype scratch — the /prototype skill deletes losing candidates
+  // after a winner is picked, so these are never meant to be tracked.
+  '_prototype/',
 ];
 
 function writeManagedGitignore(projectDir) {


### PR DESCRIPTION
## Problem

The `/prototype` skill writes throwaway candidate mockups under `_prototype/` and deletes losing candidates once a winner is picked — this content is scratch, never meant to be tracked. But the installer's managed `.gitignore` block didn't cover it, so **every project that uses `/prototype` risks committing prototype scratch** (a stray `git add .` sweeps it in).

## Fix

Add `_prototype/` to `MANAGED_GITIGNORE_ENTRIES` in `install/install.js`. Because the managed block is (re)written on both **install** and **update**, existing projects pick this up on their next `/update-harness` too. Artifacts stay present on disk, just out of git.

## Changes

- `install/install.js` — add `_prototype/` to the managed gitignore entries (with a comment explaining why).
- `.gitignore` — this repo's managed block updated to match.
- `install/__tests__/non-interactive.test.js` — assert the managed block includes `_prototype/`.

## Tests

- `npm run test:install` — **58 pass / 0 fail**.
- Verified locally: `git check-ignore _prototype/` now matches; `_prototype/` no longer appears as untracked.

## Notes

- Scope limited to prototypes. Research caches (`tasks/research/`, `research.md`) are intentionally **not** ignored — the `/research` skill produces a shareable cache that planner/executor read on normal `/implement` runs, so ignoring it globally would be wrong.