### PR TITLE
feat(install): fetch-on-demand harness updates, no persistent clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). This project adh
 
 ---
 
+## [Unreleased]
+
+### Changed
+
+- **Fetch-on-demand updates — no more persistent clone.** `/update-harness` no longer requires a local `claude-code-harness` clone to sit next to your project. It reads a new `update` block in `.harness-manifest.json`, fetches the harness source on demand (a shallow clone to a temp dir, discarded afterward), applies the update, and cleans up. Nothing lingers in your project, nothing to gitignore, nothing to go stale.
+- **Update channels.** The `update` block records a `channel`: `latest` (default — newest `main`), `pinned` (a version tag you opt into bumping), or `local` (a clone you point at, for harness development / offline). Set at install time or with `--update`: `--pin <version>`, `--latest`, `--local <path>`.
+- **Manifest `schemaVersion` → 2.** The old `answers.harnessRepoPath` clone pointer is replaced by the `update` block. Existing installs migrate automatically on their first `--update` (the pointer is dropped, channel defaults to `latest`) — no manual action needed.
+
+### Added
+
+- **`--source <dir>`** on `--check`/`--update` — reuse an already-materialized harness checkout instead of fetching again (used by the `/update-harness` skill to fetch once and apply).
+
+### Removed
+
+- **`--harness-repo-path` flag** and the "Harness repo path" install prompt — superseded by the update channel flags above. `--skip-pull` is now a no-op (there is no clone to pull).
+
+---
+
 ## [3.1.0] - 2026-07-17
 
 New `/wayfinder` skill and five new tracker contract scripts across all four adapters.

--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -102,7 +102,7 @@ The **Flag** column is what to pass to the installer (paired with `--yes` for no
 | `YOUR_INFRA_PERSON` | `--infra-person` | Infrastructure/cloud person | Enterprise |
 | `YOUR_DEVOPS_PERSON` | `--devops-person` | CI/CD/deployments person | Enterprise |
 | `YOUR_QA_PERSON` | `--qa-person` | QA/UAT person | Enterprise |
-| `YOUR_HARNESS_REPO_PATH` | `--harness-repo-path` | Absolute path to your local clone of `claude-code-harness` (used by `/improve-harness` to reference harness files in its proposals) | Both |
+| `YOUR_HARNESS_REPO_PATH` | `--local` / `--repo-url` | Where `/improve-harness` points for the harness source: the `--local` clone path if set, else the repo URL. No persistent clone is required — updates fetch on demand (see [Update channel](#update-channel)). | Both |
 | `CLAUDE_HARNESS_WORK_ROOT` | `--work-root` | Env var in `settings.json` consumed by `catalog-skills.js` — folder containing all your projects | Global install only |
 
 ---
@@ -193,7 +193,7 @@ Written automatically by the installer at `<target>/.claude/.harness-manifest.js
 
 | Field | Type | Description |
 |---|---|---|
-| `schemaVersion` | `number` | Manifest format version (currently `1`) |
+| `schemaVersion` | `number` | Manifest format version (currently `2`) |
 | `harnessVersion` | `string` | Harness version at install/update time (from `VERSION`) |
 | `installMode` | `"global"` \| `"project"` | How the harness was installed |
 | `workflowPack` | `"solo"` \| `"enterprise"` | Which workflow pack was chosen |
@@ -202,14 +202,24 @@ Written automatically by the installer at `<target>/.claude/.harness-manifest.js
 | `codePlatform` | `"github"` \| `"azure-repos"` \| `"none"` | Where PRs live (independent of tracker) |
 | `prdMode` | `string` | PRD output mode (`file`, `tracker`, `both-file-canonical`, `both-tracker-canonical`) |
 | `answers` | `object` | All personalization values collected during install |
-| `answers.harnessRepoPath` | `string` | Path to the harness source clone |
+| `update` | `object` | Fetch-on-demand update config (schemaVersion 2+). Replaces the old `answers.harnessRepoPath` clone pointer. |
+| `update.repoUrl` | `string` | Where to fetch the harness from (a fork URL for forks) |
+| `update.channel` | `"latest"` \| `"pinned"` \| `"local"` | How `/update-harness` resolves the source |
+| `update.pinnedVersion` | `string` \| `null` | The version tag when `channel` is `"pinned"` |
+| `update.localPath` | `string` \| `null` | A local clone path when `channel` is `"local"` (harness development / offline) |
 | `installedFiles` | `string[]` | Relative paths of every file copied during install |
 | `installedAt` | `string` | ISO timestamp of first install |
 | `updatedAt` | `string` | ISO timestamp of most recent update |
 
 The manifest is the **only** home for tracker mode and code platform flags. `tasks/tracker-config.md` keeps only personal pointers (Todoist project name, sprint naming conventions, resource names).
 
-To manually edit after install (e.g. change `harnessRepoPath` after moving the clone):
+<a id="update-channel"></a>
+**Update channel.** `/update-harness` keeps **no persistent clone**. It reads `update`, fetches the
+source on demand (shallow clone to a temp dir, discarded after), applies, and cleans up. Default is
+`latest` (newest `main`). Pin a version with `--pin <version>`, return to latest with `--latest`, or
+point at a local clone with `--local <path>` — at install time or with `--update`.
+
+To manually edit after install (e.g. switch to a pinned version):
 
 ```bash
 # Edit the manifest directly — it's plain JSON

--- a/README.md
+++ b/README.md
@@ -179,6 +179,11 @@ node claude-code-harness/install/install.js        # Windows, macOS, Linux
 bash claude-code-harness/install/install.sh
 ```
 
+**The clone you just made is disposable** — the installer copies the harness into your project's
+`.claude/` and records how to fetch updates later. You can delete `claude-code-harness/` afterward;
+`/update-harness` re-fetches the source on demand (no persistent clone is kept anywhere). See
+[Updating the harness](#updating-the-harness).
+
 The installer asks:
 1. **Global or project?** — `~/.claude/` (all projects) or `.claude/` (one repo)
 2. **Solo or Enterprise?** — Simpler issues workflow or full sprint ceremony
@@ -205,17 +210,38 @@ node claude-code-harness/install/install.js --yes --project /my/app \
 
 ## Updating the harness
 
+Updates are **fetch-on-demand** — there is no persistent clone to maintain. `/update-harness` reads
+the `update` config in your `.harness-manifest.json`, fetches the harness source (a shallow clone to a
+temp dir, discarded afterward), applies the changes, and cleans up.
+
 ```bash
 /update-harness                  # interactive — checks, shows changelog, asks before applying
 /update-harness --global         # target only the global install
 /update-harness --project        # target only the project install
 ```
 
-Or headless (no Claude needed):
+**Update channel** — how "latest" is resolved. Default is the newest `main`; you can pin a version or
+point at a local clone:
+
+| Channel | What it does | Set it with |
+|---|---|---|
+| `latest` *(default)* | Always the newest `main` on GitHub | `--latest` |
+| `pinned` | Stays on a version tag until you bump it | `--pin <version>` |
+| `local` | Updates from a local clone (harness development / offline) | `--local <path>` |
+
+The channel flags work at **install time** and with **`--update`** to re-point an existing install:
 
 ```bash
-node claude-code-harness/install/install.js --check --project /my/app   # read-only version check
-node claude-code-harness/install/install.js --update --project /my/app  # apply updates
+/update-harness --pin 3.2.0      # pin this install to v3.2.0
+/update-harness --latest         # go back to tracking the newest main
+```
+
+Headless (no Claude needed) — fetches on demand just like the skill:
+
+```bash
+node <harness-checkout>/install/install.js --check  --project /my/app   # read-only version check
+node <harness-checkout>/install/install.js --update --project /my/app   # apply updates
+# --source <dir> reuses an already-fetched checkout instead of fetching again
 ```
 
 Updates are safe:
@@ -224,7 +250,9 @@ Updates are safe:
 - **Orphaned files** (removed from the harness source) are cleaned up automatically
 - **Rollback** in one command: `cp -r "<snapshot-path>/"* "<target>/"`
 
-For installs created before v2.1, `/update-harness` runs a one-time backfill to create `.harness-manifest.json`.
+Installs created before the `update` block gains it automatically on the first update (the old
+`answers.harnessRepoPath` clone pointer is dropped). Installs created before v2.1 also run a one-time
+backfill to create `.harness-manifest.json`.
 
 ---
 

--- a/install/__tests__/non-interactive.test.js
+++ b/install/__tests__/non-interactive.test.js
@@ -9,6 +9,10 @@ const { execFileSync } = require('node:child_process');
 
 const INSTALL_JS = path.resolve(__dirname, '..', 'install.js');
 const INSTALL_SH = path.resolve(__dirname, '..', 'install.sh');
+// Install with the "local" update channel pointed at this repo so post-install
+// --check/--update/--switch-tracker read the real source tree offline (no network fetch).
+const REPO = path.resolve(__dirname, '..', '..');
+const LOCAL = ['--local', REPO];
 
 const ENTERPRISE_ONLY_AGENTS = [
   'story-understand-agent.md',
@@ -66,7 +70,7 @@ test('install.js --yes --global --dry-run completes without hanging', () => {
 test('install.js --yes --project installs without enterprise agents', () => {
   const dir = makeTempProject();
   try {
-    runInstallJs(['--yes', '--project', dir]);
+    runInstallJs(['--yes', '--project', dir, ...LOCAL]);
     const agents = fs.readdirSync(path.join(dir, '.claude', 'agents'));
     for (const enterprise of ENTERPRISE_ONLY_AGENTS) {
       assert.ok(
@@ -83,11 +87,11 @@ test('install.js --yes --project installs without enterprise agents', () => {
 test('install.js --yes --project writes a valid .harness-manifest.json', () => {
   const dir = makeTempProject();
   try {
-    runInstallJs(['--yes', '--project', dir]);
+    runInstallJs(['--yes', '--project', dir, ...LOCAL]);
     const manifestPath = path.join(dir, '.claude', '.harness-manifest.json');
     assert.ok(fs.existsSync(manifestPath), 'manifest must exist after install');
     const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
-    assert.equal(manifest.schemaVersion, 1);
+    assert.equal(manifest.schemaVersion, 2);
     assert.ok(manifest.harnessVersion, 'harnessVersion must be set');
     assert.equal(manifest.installMode, 'project');
     assert.equal(manifest.workflowPack, 'solo');
@@ -109,13 +113,14 @@ test('install.js --yes --project writes a valid .harness-manifest.json', () => {
 test('install.js --check --project after install prints valid JSON', () => {
   const dir = makeTempProject();
   try {
-    runInstallJs(['--yes', '--project', dir]);
+    runInstallJs(['--yes', '--project', dir, ...LOCAL]);
     const out = runInstallJs(['--check', '--project', dir]).toString();
     const result = JSON.parse(out);
     assert.ok(!result.error, 'no error after valid install');
     assert.ok(result.currentVersion, 'currentVersion present');
     assert.ok(result.latestVersion, 'latestVersion present');
-    assert.ok(typeof result.behind === 'number', 'behind is a number');
+    assert.equal(typeof result.updateAvailable, 'boolean', 'updateAvailable is a boolean');
+    assert.equal(result.channel, 'local', 'channel reflects the local update config');
     assert.ok(Array.isArray(result.orphans), 'orphans is an array');
     assert.ok(Array.isArray(result.drifted), 'drifted is an array');
     assert.equal(result.drifted.length, 0, 'no drift right after install');
@@ -127,7 +132,7 @@ test('install.js --check --project after install prints valid JSON', () => {
 test('install.js --check detects drifted files when installed copy differs from source', () => {
   const dir = makeTempProject();
   try {
-    runInstallJs(['--yes', '--project', dir]);
+    runInstallJs(['--yes', '--project', dir, ...LOCAL]);
     const claudeDir = path.join(dir, '.claude');
     const manifest = JSON.parse(fs.readFileSync(path.join(claudeDir, '.harness-manifest.json'), 'utf8'));
     const firstSkill = manifest.installedFiles.find(f => f.startsWith('skills/') && f.endsWith('.md'));
@@ -161,7 +166,7 @@ test('install.js --check without manifest returns no-manifest error', () => {
 test('install.js --update --project after install succeeds and bumps manifest', () => {
   const dir = makeTempProject();
   try {
-    runInstallJs(['--yes', '--project', dir]);
+    runInstallJs(['--yes', '--project', dir, ...LOCAL]);
     const manifestPath = path.join(dir, '.claude', '.harness-manifest.json');
     const before = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
 
@@ -181,10 +186,24 @@ test('install.js --update --project after install succeeds and bumps manifest', 
   }
 });
 
+test('install.js --update --pin re-points channel to pinned and persists it', () => {
+  const dir = makeTempProject();
+  try {
+    runInstallJs(['--yes', '--project', dir, ...LOCAL]);
+    // Switch to a pinned channel during update; --source keeps it offline.
+    runInstallJs(['--update', '--project', dir, '--pin', '3.1.0', '--source', REPO]);
+    const m = JSON.parse(fs.readFileSync(path.join(dir, '.claude', '.harness-manifest.json'), 'utf8'));
+    assert.equal(m.update.channel, 'pinned', 'channel switched to pinned');
+    assert.equal(m.update.pinnedVersion, '3.1.0', 'pinned version persisted');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('install.js --switch-tracker todoist updates manifest and copies scripts', () => {
   const dir = makeTempProject();
   try {
-    runInstallJs(['--yes', '--project', dir]);
+    runInstallJs(['--yes', '--project', dir, ...LOCAL]);
     const manifestPath = path.join(dir, '.claude', '.harness-manifest.json');
     const before = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
     assert.equal(before.tracker, 'local', 'default tracker should be local (D2)');
@@ -270,7 +289,7 @@ test('install.js rejects an invalid enum flag value', () => {
 test('install.js prints an actionable re-run command when values are left as placeholders', () => {
   const dir = makeTempProject();
   try {
-    const out = runInstallJs(['--yes', '--project', dir]).toString();
+    const out = runInstallJs(['--yes', '--project', dir, ...LOCAL]).toString();
     assert.ok(out.includes('re-running with:'), 'should offer a re-run command');
     assert.ok(out.includes('--name'), 'should name the flag that fills YOUR_NAME');
     assert.ok(out.includes('--project-name'), 'should name the flag that fills YOUR_PROJECT_NAME');
@@ -332,7 +351,7 @@ test('install.sh --yes --project installs without enterprise agents', () => {
 test('install.js --yes defaults to tracker=local with all 13 local scripts in active/', () => {
   const dir = makeTempProject();
   try {
-    runInstallJs(['--yes', '--project', dir]);
+    runInstallJs(['--yes', '--project', dir, ...LOCAL]);
     const manifest = JSON.parse(fs.readFileSync(path.join(dir, '.claude', '.harness-manifest.json'), 'utf8'));
     assert.equal(manifest.tracker, 'local', 'D2: --yes defaults to local');
     assert.strictEqual(manifest.trackerMirror, undefined, 'no mirror in local mode');
@@ -358,7 +377,7 @@ test('install.js --yes defaults to tracker=local with all 13 local scripts in ac
 test('install.js --yes writes managed gitignore block, idempotent on re-install', () => {
   const dir = makeTempProject();
   try {
-    runInstallJs(['--yes', '--project', dir]);
+    runInstallJs(['--yes', '--project', dir, ...LOCAL]);
     const gitignorePath = path.join(dir, '.gitignore');
     assert.ok(fs.existsSync(gitignorePath), '.gitignore must be created');
     const content = fs.readFileSync(gitignorePath, 'utf8');
@@ -367,7 +386,7 @@ test('install.js --yes writes managed gitignore block, idempotent on re-install'
     assert.ok(content.includes('tasks/todo.md'), 'tasks/todo.md must be in block');
 
     // Re-run: block should appear exactly once
-    runInstallJs(['--yes', '--project', dir]);
+    runInstallJs(['--yes', '--project', dir, ...LOCAL]);
     const content2 = fs.readFileSync(gitignorePath, 'utf8');
     const count = content2.split('claude-code-harness managed').length - 1;
     assert.equal(count, 2, 'exactly 2 sentinel lines (start+end) after re-install');
@@ -379,7 +398,7 @@ test('install.js --yes writes managed gitignore block, idempotent on re-install'
 test('install.js --tracker github --yes installs github adapter', () => {
   const dir = makeTempProject();
   try {
-    runInstallJs(['--yes', '--project', dir, '--tracker', 'github']);
+    runInstallJs(['--yes', '--project', dir, '--tracker', 'github', ...LOCAL]);
     const manifest = JSON.parse(fs.readFileSync(path.join(dir, '.claude', '.harness-manifest.json'), 'utf8'));
     assert.equal(manifest.tracker, 'github');
     const activeDir = path.join(dir, '.claude', 'trackers', 'active');
@@ -394,7 +413,7 @@ test('install.js --update crossing: old manifest gains trackerMirror, archives t
   const dir = makeTempProject();
   try {
     // Simulate pre-modes manifest by installing then stripping the new field
-    runInstallJs(['--yes', '--project', dir, '--tracker', 'github']);
+    runInstallJs(['--yes', '--project', dir, '--tracker', 'github', ...LOCAL]);
     const manifestPath = path.join(dir, '.claude', '.harness-manifest.json');
     const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
     delete manifest.trackerMirror;
@@ -428,7 +447,7 @@ test('install.js --update crossing: old manifest gains trackerMirror, archives t
 test('install.js --update crossing: no todo.md present → no archive, no error', () => {
   const dir = makeTempProject();
   try {
-    runInstallJs(['--yes', '--project', dir, '--tracker', 'github']);
+    runInstallJs(['--yes', '--project', dir, '--tracker', 'github', ...LOCAL]);
     const manifestPath = path.join(dir, '.claude', '.harness-manifest.json');
     const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
     delete manifest.trackerMirror;
@@ -451,7 +470,7 @@ test('install.js --update crossing: no todo.md present → no archive, no error'
 test('install.js --switch-tracker local creates tasks/issues/ and sets trackerMirror=false', () => {
   const dir = makeTempProject();
   try {
-    runInstallJs(['--yes', '--project', dir, '--tracker', 'github']);
+    runInstallJs(['--yes', '--project', dir, '--tracker', 'github', ...LOCAL]);
     runInstallJs(['--switch-tracker', 'local', '--project', dir]);
     const manifest = JSON.parse(fs.readFileSync(path.join(dir, '.claude', '.harness-manifest.json'), 'utf8'));
     assert.equal(manifest.tracker, 'local');

--- a/install/__tests__/source.test.js
+++ b/install/__tests__/source.test.js
@@ -1,0 +1,201 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  DEFAULT_REPO_URL,
+  normalizeUpdateConfig,
+  pinnedRefCandidates,
+  resolveSource,
+  migrateUpdateConfig,
+} = require('../lib/source.js');
+
+// Fresh throwaway temp dir per call, tracked for cleanup.
+const tmpDirs = [];
+function makeTmp() {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'cch-src-test-'));
+  tmpDirs.push(d);
+  return d;
+}
+test.after(() => {
+  for (const d of tmpDirs) { try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* noop */ } }
+});
+
+// ── normalizeUpdateConfig ─────────────────────────────────────────────────────
+
+test('normalizeUpdateConfig_Empty_FillsLatestDefaults', () => {
+  const cfg = normalizeUpdateConfig(undefined);
+  assert.strictEqual(cfg.channel, 'latest');
+  assert.strictEqual(cfg.repoUrl, DEFAULT_REPO_URL);
+  assert.strictEqual(cfg.pinnedVersion, null);
+  assert.strictEqual(cfg.localPath, null);
+});
+
+test('normalizeUpdateConfig_UnknownChannel_FallsBackToLatest', () => {
+  assert.strictEqual(normalizeUpdateConfig({ channel: 'bogus' }).channel, 'latest');
+});
+
+test('normalizeUpdateConfig_TrimsAndPreservesFields', () => {
+  const cfg = normalizeUpdateConfig({
+    channel: 'pinned', pinnedVersion: '  3.2.0 ', repoUrl: ' https://x/y ', localPath: '  ',
+  });
+  assert.strictEqual(cfg.channel, 'pinned');
+  assert.strictEqual(cfg.pinnedVersion, '3.2.0');
+  assert.strictEqual(cfg.repoUrl, 'https://x/y');
+  assert.strictEqual(cfg.localPath, null); // whitespace-only → null
+});
+
+// ── pinnedRefCandidates ───────────────────────────────────────────────────────
+
+test('pinnedRefCandidates_BareVersion_AddsVPrefixAlternate', () => {
+  assert.deepStrictEqual(pinnedRefCandidates('3.2.0'), ['3.2.0', 'v3.2.0']);
+});
+
+test('pinnedRefCandidates_VPrefixed_AddsBareAlternate', () => {
+  assert.deepStrictEqual(pinnedRefCandidates('v3.2.0'), ['v3.2.0', '3.2.0']);
+});
+
+// ── resolveSource: local channel ──────────────────────────────────────────────
+
+test('resolveSource_Local_ReturnsPathWithNoopCleanup', () => {
+  const dir = makeTmp();
+  fs.writeFileSync(path.join(dir, 'VERSION'), '3.2.0\n');
+  const src = resolveSource({ channel: 'local', localPath: dir });
+  assert.strictEqual(src.dir, dir);
+  assert.strictEqual(src.ephemeral, false);
+  src.cleanup(); // must not throw or delete
+  assert.ok(fs.existsSync(dir), 'local dir must survive cleanup');
+});
+
+test('resolveSource_LocalMissingPath_Throws', () => {
+  assert.throws(() => resolveSource({ channel: 'local', localPath: null }), /localPath is not set/);
+});
+
+test('resolveSource_LocalNoVersionFile_Throws', () => {
+  const dir = makeTmp(); // exists but no VERSION
+  assert.throws(() => resolveSource({ channel: 'local', localPath: dir }), /no VERSION file/);
+});
+
+// ── resolveSource: latest/pinned via injected fake git ────────────────────────
+
+// Fake git that "clones" by writing a VERSION file into the target dir.
+function fakeGitSuccess(version = '9.9.9') {
+  return (args) => {
+    const target = args[args.length - 1];
+    fs.writeFileSync(path.join(target, 'VERSION'), `${version}\n`);
+    return { status: 0, stdout: Buffer.from(''), stderr: Buffer.from('') };
+  };
+}
+
+test('resolveSource_Latest_ClonesToTempAndCleansUp', () => {
+  const src = resolveSource(
+    { channel: 'latest' },
+    { runGit: fakeGitSuccess(), mkTempDir: makeTmp },
+  );
+  assert.strictEqual(src.ephemeral, true);
+  assert.ok(fs.existsSync(path.join(src.dir, 'VERSION')));
+  src.cleanup();
+  assert.ok(!fs.existsSync(src.dir), 'ephemeral dir must be removed by cleanup');
+});
+
+test('resolveSource_Latest_UsesShallowCloneNoBranch', () => {
+  let captured;
+  resolveSource({ channel: 'latest' }, {
+    runGit: (args) => { captured = args; return fakeGitSuccess()(args); },
+    mkTempDir: makeTmp,
+  });
+  assert.ok(captured.includes('--depth') && captured.includes('1'), 'must be a shallow clone');
+  assert.ok(!captured.includes('--branch'), 'latest must not pin a branch');
+});
+
+test('resolveSource_Pinned_PassesBranchTag', () => {
+  let captured;
+  resolveSource({ channel: 'pinned', pinnedVersion: '3.2.0' }, {
+    runGit: (args) => { captured = args; return fakeGitSuccess()(args); },
+    mkTempDir: makeTmp,
+  });
+  const bi = captured.indexOf('--branch');
+  assert.ok(bi !== -1, 'pinned must pass --branch');
+  assert.strictEqual(captured[bi + 1], '3.2.0');
+});
+
+test('resolveSource_Pinned_RetriesVPrefixOnFirstFailure', () => {
+  const tried = [];
+  const runGit = (args) => {
+    const bi = args.indexOf('--branch');
+    const ref = args[bi + 1];
+    tried.push(ref);
+    if (ref === '3.2.0') return { status: 128, stdout: Buffer.from(''), stderr: Buffer.from('not found') };
+    // second candidate succeeds
+    const target = args[args.length - 1];
+    fs.writeFileSync(path.join(target, 'VERSION'), '3.2.0\n');
+    return { status: 0, stdout: Buffer.from(''), stderr: Buffer.from('') };
+  };
+  const src = resolveSource({ channel: 'pinned', pinnedVersion: '3.2.0' }, { runGit, mkTempDir: makeTmp });
+  assert.deepStrictEqual(tried, ['3.2.0', 'v3.2.0']);
+  assert.ok(fs.existsSync(path.join(src.dir, 'VERSION')));
+});
+
+test('resolveSource_CloneFails_ThrowsWithStderr', () => {
+  const runGit = () => ({ status: 128, stdout: Buffer.from(''), stderr: Buffer.from('Could not resolve host') });
+  assert.throws(
+    () => resolveSource({ channel: 'latest' }, { runGit, mkTempDir: makeTmp }),
+    /Could not fetch the latest version.*Could not resolve host/s,
+  );
+});
+
+test('resolveSource_PinnedNoVersion_Throws', () => {
+  assert.throws(
+    () => resolveSource({ channel: 'pinned', pinnedVersion: null }, { runGit: fakeGitSuccess(), mkTempDir: makeTmp }),
+    /pinnedVersion is not set/,
+  );
+});
+
+// ── migrateUpdateConfig ───────────────────────────────────────────────────────
+
+test('migrateUpdateConfig_LegacyManifest_AddsUpdateBlockRemovesRepoPath', () => {
+  const legacy = {
+    schemaVersion: 1,
+    harnessVersion: '3.1.0',
+    answers: { userName: 'Alex', harnessRepoPath: '/nonexistent/path' },
+  };
+  const { changed, manifest } = migrateUpdateConfig(legacy);
+  assert.strictEqual(changed, true);
+  assert.ok(manifest.update);
+  assert.strictEqual(manifest.schemaVersion, 2, 'schemaVersion bumped to 2');
+  assert.strictEqual(manifest.update.channel, 'latest');
+  assert.strictEqual(manifest.update.repoUrl, DEFAULT_REPO_URL);
+  assert.strictEqual(manifest.answers.harnessRepoPath, undefined);
+  assert.strictEqual(manifest.answers.userName, 'Alex', 'other answers preserved');
+});
+
+test('migrateUpdateConfig_Immutable_DoesNotMutateInput', () => {
+  const legacy = { answers: { harnessRepoPath: '/x' } };
+  migrateUpdateConfig(legacy);
+  assert.strictEqual(legacy.answers.harnessRepoPath, '/x', 'input must be untouched');
+});
+
+test('migrateUpdateConfig_AlreadyMigrated_NoChange', () => {
+  const m = { update: { channel: 'latest', repoUrl: DEFAULT_REPO_URL, pinnedVersion: null, localPath: null } };
+  const { changed, manifest } = migrateUpdateConfig(m);
+  assert.strictEqual(changed, false);
+  assert.strictEqual(manifest, m);
+});
+
+test('migrateUpdateConfig_PreservesForkRemoteUrl', () => {
+  const dir = makeTmp();
+  fs.writeFileSync(path.join(dir, 'VERSION'), '3.1.0\n');
+  const legacy = { answers: { harnessRepoPath: dir } };
+  const runGit = (args) => {
+    if (args.includes('remote')) {
+      return { status: 0, stdout: Buffer.from('https://github.com/fork/harness.git\n'), stderr: Buffer.from('') };
+    }
+    return { status: 1, stdout: Buffer.from(''), stderr: Buffer.from('') };
+  };
+  const { manifest } = migrateUpdateConfig(legacy, { runGit });
+  assert.strictEqual(manifest.update.repoUrl, 'https://github.com/fork/harness');
+});

--- a/install/__tests__/substitute.test.js
+++ b/install/__tests__/substitute.test.js
@@ -374,14 +374,17 @@ test('runCheck_ValidManifest_ReturnsVersionInfo', () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'check-test-'));
   const REPO = path.resolve(__dirname, '../..');
   try {
+    // Use the offline "local" channel pointed at this repo so the check reads the
+    // real source tree without a network fetch.
     const manifest = {
-      schemaVersion: 1,
+      schemaVersion: 2,
       harnessVersion: '1.0.0',
       installMode: 'project',
       workflowPack: 'solo',
       tracker: 'github',
       prdMode: 'file',
-      answers: { harnessRepoPath: REPO },
+      answers: {},
+      update: { repoUrl: 'https://github.com/x/y', channel: 'local', pinnedVersion: null, localPath: REPO },
       installedFiles: ['skills/implement/SKILL.md', 'hooks/safety-check.js'],
       installedAt: '2026-01-01T00:00:00.000Z',
       updatedAt: '2026-01-01T00:00:00.000Z',
@@ -389,10 +392,63 @@ test('runCheck_ValidManifest_ReturnsVersionInfo', () => {
     fs.writeFileSync(path.join(dir, '.harness-manifest.json'), JSON.stringify(manifest), 'utf8');
     const result = runCheck(dir);
     assert.ok(!result.error, 'no error for valid manifest');
+    assert.equal(result.channel, 'local');
     assert.equal(result.currentVersion, '1.0.0');
     assert.ok(result.latestVersion, 'latestVersion present');
-    assert.ok(typeof result.behind === 'number', 'behind is a number');
+    assert.equal(typeof result.updateAvailable, 'boolean', 'updateAvailable is a boolean');
     assert.ok(Array.isArray(result.orphans), 'orphans is an array');
+    assert.ok(Array.isArray(result.drifted), 'drifted is an array');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runCheck_WithSourceDirOption_BypassesFetchEvenOnLatestChannel', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'check-source-'));
+  const REPO = path.resolve(__dirname, '../..');
+  try {
+    const manifest = {
+      schemaVersion: 2,
+      harnessVersion: '1.0.0',
+      installMode: 'project',
+      workflowPack: 'solo',
+      tracker: 'github',
+      prdMode: 'file',
+      answers: {},
+      // channel "latest" would normally fetch; --source must override that.
+      update: { repoUrl: 'https://github.com/x/y', channel: 'latest', pinnedVersion: null, localPath: null },
+      installedFiles: ['skills/implement/SKILL.md'],
+      installedAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    };
+    fs.writeFileSync(path.join(dir, '.harness-manifest.json'), JSON.stringify(manifest), 'utf8');
+    // The install.js wrapper injects --source from CLI args; the option itself lives
+    // on the updater impl, so exercise that directly.
+    const { runCheck: runCheckImpl } = require('../lib/updater.js');
+    const result = runCheckImpl(dir, { sourceDir: REPO });
+    assert.ok(!result.error, 'no error when source dir is supplied');
+    assert.ok(result.latestVersion, 'latestVersion read from the supplied source');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runCheck_LegacyManifestMissingClone_ReturnsFetchErrorNotCrash', () => {
+  // A pre-migration manifest whose old clone path is gone. migrateUpdateConfig
+  // sends it to channel "latest"; with a bogus repoUrl the fetch fails cleanly
+  // rather than throwing.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'check-legacy-'));
+  try {
+    const manifest = {
+      schemaVersion: 1,
+      harnessVersion: '1.0.0',
+      answers: { harnessRepoPath: '/definitely/not/here' },
+      update: { repoUrl: 'file:///definitely/not/a/repo', channel: 'latest', pinnedVersion: null, localPath: null },
+      installedFiles: [],
+    };
+    fs.writeFileSync(path.join(dir, '.harness-manifest.json'), JSON.stringify(manifest), 'utf8');
+    const result = runCheck(dir);
+    assert.equal(result.error, 'fetch-failed');
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }

--- a/install/install.js
+++ b/install/install.js
@@ -21,9 +21,24 @@ const {
   runSwitchTracker: runSwitchTrackerImpl, backfillManifest: backfillManifestImpl,
   HARNESS_HOOK_SCRIPTS, ENTERPRISE_ONLY_AGENTS,
 } = require('./lib/updater.js');
+const { DEFAULT_REPO_URL } = require('./lib/source.js');
+
+// Build the fetch-on-demand update config from CLI flags. Default: latest from
+// GitHub. --pin <ver> pins a version; --local <path> points at a local clone
+// (used for harness development). See install/lib/source.js.
+function buildUpdateConfig(cliArgs) {
+  const repoUrl = cliArgs.repoUrl || DEFAULT_REPO_URL;
+  if (cliArgs.localPath) {
+    return { repoUrl, channel: 'local', pinnedVersion: null, localPath: path.resolve(cliArgs.localPath) };
+  }
+  if (cliArgs.pinnedVersion) {
+    return { repoUrl, channel: 'pinned', pinnedVersion: cliArgs.pinnedVersion, localPath: null };
+  }
+  return { repoUrl, channel: 'latest', pinnedVersion: null, localPath: null };
+}
 
 const REPO_DIR = path.resolve(__dirname, '..');
-const MANIFEST_SCHEMA_VERSION = 1;
+const MANIFEST_SCHEMA_VERSION = 2;
 
 // ── Node version gate ────────────────────────────────────────────────────────
 const major = parseInt(process.versions.node.split('.')[0], 10);
@@ -63,7 +78,10 @@ const VALUE_FLAGS = {
   '--devops-person': 'devopsPerson',
   '--qa-person': 'qaPerson',
   '--work-root': 'workRoot',
-  '--harness-repo-path': 'harnessRepoPath',
+  '--pin': 'pinnedVersion',
+  '--local': 'localPath',
+  '--repo-url': 'repoUrl',
+  '--source': 'source',
   '--code-platform': 'codePlatform',
   '--tracker-mirror': 'trackerMirror',
 };
@@ -94,7 +112,8 @@ for (let i = 0; i < args.length; i++) {
     if (next && !next.startsWith('-')) { switchTracker = next; i++; }
   }
   else if (a === '--backfill') { /* triggers backfill — consumed in main */ }
-  else if (a === '--skip-pull') { /* consumed by runUpdate */ }
+  else if (a === '--skip-pull') { /* legacy no-op — fetch-on-demand has nothing to pull */ }
+  else if (a === '--latest') { cli.channelLatest = '1'; }
   else if (a === '--seed') { /* handled post-install — seeds lessons.md from ~/.claude/learnings/ */ }
   else if (a === '--help' || a === '-h') {
     console.log(`  Usage:
@@ -117,7 +136,14 @@ for (let i = 0; i < args.length; i++) {
     --todoist-project <str>             Todoist project (todoist tracker)
     --org / --lead-dev / --infra-person / --devops-person / --qa-person   team (enterprise)
     --work-root <path>                  work folder (global installs)
-    --harness-repo-path <path>          local claude-code-harness clone
+
+  Update channel (how /update-harness fetches new versions — default: latest from GitHub):
+    --pin <version>                     pin to a version tag (opt into bumps with --update later)
+    --latest                            (re)set the channel to latest
+    --local <path>                      update from a local clone (harness development / offline)
+    --repo-url <url>                    fetch from a fork instead of the canonical repo
+  These flags work at install time and with --update to re-point an existing install.
+  --check/--update also accept --source <dir> to reuse an already-fetched checkout.
 
   Example — fully non-interactive:
     node install/install.js --yes --project /my/app --name "Alex" --project-name "my-app"
@@ -131,11 +157,19 @@ for (let i = 0; i < args.length; i++) {
 let rl = null;
 const ask = (q) => new Promise((resolve) => rl.question(q, (ans) => resolve(ans)));
 
-// ── Thin wrappers that inject REPO_DIR ───────────────────────────────────────
-function runCheck(target) { return runCheckImpl(target, REPO_DIR); }
-function runUpdate(target) { return runUpdateImpl(target, { repoDir: REPO_DIR, cliArgs: args }); }
-function runSwitchTracker(target, tracker) { return runSwitchTrackerImpl(target, tracker, REPO_DIR); }
-function backfillManifest(target, opts = {}) { return backfillManifestImpl(target, opts, REPO_DIR); }
+// ── Thin wrappers ────────────────────────────────────────────────────────────
+// Update/check/switch no longer read a persistent clone — the harness source is
+// fetched on demand from the manifest's `update` config (see install/lib/source.js).
+// A pre-materialized source can be reused via --source (set from cli.source).
+function runCheck(target) { return runCheckImpl(target, { sourceDir: cli.source || null }); }
+function runUpdate(target) {
+  // --pin / --latest / --local / --repo-url during update re-point the channel.
+  const hasChannelFlag = cli.localPath || cli.pinnedVersion || cli.repoUrl || cli.channelLatest;
+  const channelOverride = hasChannelFlag ? buildUpdateConfig(cli) : null;
+  return runUpdateImpl(target, { cliArgs: args, sourceDir: cli.source || null, channelOverride });
+}
+function runSwitchTracker(target, tracker) { return runSwitchTrackerImpl(target, tracker); }
+function backfillManifest(target, opts = {}) { return backfillManifestImpl(target, opts); }
 
 // ── Managed gitignore block (D4) ────────────────────────────────────────────
 const GITIGNORE_SENTINEL_START = '# >>> claude-code-harness managed — do not edit inside this block >>>';
@@ -478,7 +512,9 @@ async function main() {
     workRoot = await promptValue(cli.workRoot, '    Work root (folder containing projects) : ', 'C:\\YOUR_WORK_FOLDER');
   }
 
-  const harnessRepoPath = await promptValue(cli.harnessRepoPath, `    Harness repo path [${REPO_DIR}]: `, REPO_DIR);
+  // Update channel (fetch-on-demand). Default: latest from GitHub. No persistent
+  // clone is recorded — /update-harness fetches the source when it runs.
+  const update = buildUpdateConfig(cli);
   console.log('');
 
   // ── Dry run ────────────────────────────────────────────────────────────────
@@ -660,7 +696,10 @@ async function main() {
     projectName, userName,
     adoProject, adoRepo, adoOrgPath,
     orgName, leadDev, infraPerson, devopsPerson, qaPerson,
-    harnessRepoPath, todoistProject, workRoot, isGlobal: mode === 'global',
+    // YOUR_HARNESS_REPO_PATH is only meaningful for a local clone (improve-harness).
+    // On latest/pinned channels there is no clone, so fall back to the repo URL.
+    harnessRepoPath: update.localPath || update.repoUrl,
+    todoistProject, workRoot, isGlobal: mode === 'global',
     prdMode,
   });
 
@@ -700,8 +739,9 @@ async function main() {
       adoProject, adoRepo, adoOrgPath,
       todoistProject,
       orgName, leadDev, infraPerson, devopsPerson, qaPerson,
-      harnessRepoPath, workRoot,
+      workRoot,
     },
+    update,
     installedFiles: installedFiles.sort(),
     now,
   });

--- a/install/lib/source.js
+++ b/install/lib/source.js
@@ -1,0 +1,148 @@
+'use strict';
+
+// Fetch-on-demand harness source resolution.
+//
+// The updater no longer depends on a persistent local clone. Instead it resolves
+// a *source directory* on demand from the manifest's `update` config, uses it, and
+// (for fetched sources) deletes it. Three channels:
+//
+//   latest  (default) → shallow-clone the default branch into a temp dir
+//   pinned            → shallow-clone a specific version tag into a temp dir
+//   local             → use an existing local clone in place (dogfood / offline dev)
+//
+// git and temp-dir creation are injectable so this module is unit-testable without
+// network access.
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const DEFAULT_REPO_URL = 'https://github.com/anudeeps28/claude-code-harness';
+const VALID_CHANNELS = new Set(['latest', 'pinned', 'local']);
+
+function defaultRunGit(args, opts = {}) {
+  return spawnSync('git', args, { timeout: opts.timeout || 60000, stdio: 'pipe' });
+}
+
+function defaultMkTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'cch-src-'));
+}
+
+function rmTemp(dir) {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
+}
+
+// Coerce a manifest `update` block (possibly partial or absent) into a well-formed
+// config with defaults filled. Never mutates its input.
+function normalizeUpdateConfig(update) {
+  const u = update && typeof update === 'object' ? update : {};
+  const channel = VALID_CHANNELS.has(u.channel) ? u.channel : 'latest';
+  const str = (v) => (typeof v === 'string' && v.trim() ? v.trim() : null);
+  return {
+    repoUrl: str(u.repoUrl) || DEFAULT_REPO_URL,
+    channel,
+    pinnedVersion: str(u.pinnedVersion),
+    localPath: str(u.localPath),
+  };
+}
+
+// Candidate git refs to try for a pinned version, tolerating both "3.2.0" and
+// "v3.2.0" tag naming.
+function pinnedRefCandidates(version) {
+  const v = version.trim();
+  const alt = v.startsWith('v') ? v.slice(1) : `v${v}`;
+  return alt === v ? [v] : [v, alt];
+}
+
+// Resolve a usable harness source directory from the update config.
+// Returns { dir, cleanup, ephemeral, channel }. Callers MUST invoke cleanup()
+// (a no-op for the local channel) when done — use try/finally.
+function resolveSource(update, opts = {}) {
+  const cfg = normalizeUpdateConfig(update);
+  const runGit = opts.runGit || defaultRunGit;
+  const mkTempDir = opts.mkTempDir || defaultMkTempDir;
+
+  if (cfg.channel === 'local') {
+    if (!cfg.localPath) {
+      throw new Error('update.channel is "local" but update.localPath is not set. '
+        + 'Point it at a harness clone, or switch to --latest.');
+    }
+    if (!fs.existsSync(cfg.localPath) || !fs.existsSync(path.join(cfg.localPath, 'VERSION'))) {
+      throw new Error(`Local harness source not found at ${cfg.localPath} (no VERSION file). `
+        + 'Fix update.localPath in the manifest, or switch to --latest.');
+    }
+    return { dir: cfg.localPath, cleanup: () => {}, ephemeral: false, channel: 'local' };
+  }
+
+  // latest | pinned → shallow clone into a throwaway temp dir.
+  const refs = cfg.channel === 'pinned'
+    ? pinnedRefCandidates(cfg.pinnedVersion || '')
+    : [null];
+  if (cfg.channel === 'pinned' && !cfg.pinnedVersion) {
+    throw new Error('update.channel is "pinned" but update.pinnedVersion is not set.');
+  }
+
+  let lastErr = '';
+  for (const ref of refs) {
+    const tmp = mkTempDir();
+    const args = ['clone', '--depth', '1'];
+    if (ref) args.push('--branch', ref);
+    args.push(cfg.repoUrl, tmp);
+    const res = runGit(args, { timeout: opts.timeout || 60000 });
+    if (res && res.status === 0 && fs.existsSync(path.join(tmp, 'VERSION'))) {
+      return { dir: tmp, cleanup: () => rmTemp(tmp), ephemeral: true, channel: cfg.channel };
+    }
+    lastErr = (res && res.stderr ? res.stderr.toString().trim() : '') || lastErr;
+    rmTemp(tmp);
+  }
+
+  const what = cfg.channel === 'pinned'
+    ? `version "${cfg.pinnedVersion}"`
+    : 'the latest version';
+  throw new Error(`Could not fetch ${what} from ${cfg.repoUrl}.\n`
+    + `  ${lastErr || 'Check your network connection and the repo URL.'}`);
+}
+
+// Migrate a legacy manifest (with answers.harnessRepoPath and no `update` block)
+// to the fetch-on-demand shape. Returns { changed, manifest } — never mutates input.
+// Best-effort: if the old clone still has an origin remote, its URL is preserved so
+// forks keep updating from their own remote.
+function migrateUpdateConfig(manifest, opts = {}) {
+  if (manifest && manifest.update && typeof manifest.update === 'object') {
+    return { changed: false, manifest };
+  }
+  const answers = (manifest && manifest.answers) || {};
+  const oldPath = answers.harnessRepoPath;
+  let repoUrl = DEFAULT_REPO_URL;
+
+  if (oldPath && fs.existsSync(oldPath)) {
+    const runGit = opts.runGit || defaultRunGit;
+    try {
+      const res = runGit(['-C', oldPath, 'remote', 'get-url', 'origin'], { timeout: 5000 });
+      if (res && res.status === 0) {
+        const url = (res.stdout || '').toString().trim();
+        if (url) repoUrl = url.replace(/\.git$/, '');
+      }
+    } catch { /* fall back to default */ }
+  }
+
+  const newAnswers = { ...answers };
+  delete newAnswers.harnessRepoPath;
+  const migrated = {
+    ...manifest,
+    schemaVersion: 2,
+    answers: newAnswers,
+    update: { repoUrl, channel: 'latest', pinnedVersion: null, localPath: null },
+  };
+  return { changed: true, manifest: migrated };
+}
+
+module.exports = {
+  DEFAULT_REPO_URL,
+  VALID_CHANNELS,
+  normalizeUpdateConfig,
+  pinnedRefCandidates,
+  resolveSource,
+  migrateUpdateConfig,
+};

--- a/install/lib/substitution.js
+++ b/install/lib/substitution.js
@@ -4,6 +4,7 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const { walk } = require('../../hooks/lib/walk.js');
+const { DEFAULT_REPO_URL } = require('./source.js');
 
 const IS_WINDOWS = process.platform === 'win32';
 
@@ -95,9 +96,9 @@ function buildSettings({ hooksUnix, sessionStartMsg: _sessionStartMsg, workRoot,
   return settings;
 }
 
-function buildManifest({ harnessVersion, installMode, workflowPack, tracker, trackerMirror, codePlatform, prdMode, answers, installedFiles, now }) {
+function buildManifest({ harnessVersion, installMode, workflowPack, tracker, trackerMirror, codePlatform, prdMode, answers, update, installedFiles, now }) {
   const manifest = {
-    schemaVersion: 1,
+    schemaVersion: 2,
     harnessVersion,
     installMode,
     workflowPack,
@@ -105,6 +106,9 @@ function buildManifest({ harnessVersion, installMode, workflowPack, tracker, tra
     codePlatform: codePlatform || 'none',
     prdMode,
     answers,
+    // Fetch-on-demand update config (schemaVersion 2+). Replaces the old
+    // answers.harnessRepoPath persistent-clone pointer. See install/lib/source.js.
+    update: update || { repoUrl: DEFAULT_REPO_URL, channel: 'latest', pinnedVersion: null, localPath: null },
     installedFiles,
     installedAt: now,
     updatedAt: now,
@@ -115,9 +119,15 @@ function buildManifest({ harnessVersion, installMode, workflowPack, tracker, tra
   return manifest;
 }
 
-function subsFromManifest(manifest, target, harnessRepoPath) {
+function subsFromManifest(manifest, target) {
   const answers = manifest.answers || {};
+  const update = manifest.update || {};
   const mode = manifest.installMode || 'project';
+  // YOUR_HARNESS_REPO_PATH is only meaningful for a local clone (the improve-harness
+  // workflow points the user at it). On the fetch-on-demand channels there is no
+  // persistent clone, so fall back to the legacy pointer (pre-migration manifests)
+  // and finally the repo URL, which still tells the user where to clone from.
+  const harnessRepoPath = update.localPath || answers.harnessRepoPath || update.repoUrl || DEFAULT_REPO_URL;
   const hooksUnix = mode === 'global'
     ? `${os.homedir().replace(/\\/g, '/')}/.claude/hooks`
     : toUnixPath(path.join(target, 'hooks'));
@@ -137,7 +147,7 @@ function subsFromManifest(manifest, target, harnessRepoPath) {
     infraPerson: answers.infraPerson || 'YOUR_INFRA_PERSON',
     devopsPerson: answers.devopsPerson || 'YOUR_DEVOPS_PERSON',
     qaPerson: answers.qaPerson || 'YOUR_QA_PERSON',
-    harnessRepoPath: answers.harnessRepoPath || harnessRepoPath,
+    harnessRepoPath,
     todoistProject: answers.todoistProject || 'YOUR_TODOIST_PROJECT',
     workRoot: answers.workRoot || '',
     isGlobal: mode === 'global',

--- a/install/lib/updater.js
+++ b/install/lib/updater.js
@@ -11,6 +11,9 @@ const {
   toUnixPath, substituteInTree, buildSettings,
   buildManifest, subsFromManifest,
 } = require('./substitution.js');
+const {
+  DEFAULT_REPO_URL, normalizeUpdateConfig, resolveSource, migrateUpdateConfig,
+} = require('./source.js');
 
 const HARNESS_HOOK_SCRIPTS = new Set([
   'safety-check.js',
@@ -226,7 +229,7 @@ function printDryRun(ctx, repoDir) {
   console.log('  Run without --dry-run to install.');
 }
 
-function runCheck(target, repoDir) {
+function runCheck(target, opts = {}) {
   const manifestPath = path.join(target, '.harness-manifest.json');
   if (!fs.existsSync(manifestPath)) {
     return { error: 'no-manifest', message: 'No .harness-manifest.json found. Run the installer first, or use --update to backfill.' };
@@ -239,84 +242,81 @@ function runCheck(target, repoDir) {
     return { error: 'invalid-manifest', message: `Cannot parse .harness-manifest.json: ${e.message}` };
   }
 
-  const harnessRepoPath = (manifest.answers && manifest.answers.harnessRepoPath) || repoDir;
-  if (!fs.existsSync(harnessRepoPath) || !fs.existsSync(path.join(harnessRepoPath, 'VERSION'))) {
-    return { error: 'clone-not-found', message: `Harness clone not found at ${harnessRepoPath}. Git clone it and re-run.` };
+  // Migrate the legacy persistent-clone shape in memory. The change is persisted
+  // on the next --update, not during a read-only check.
+  const { manifest: m } = migrateUpdateConfig(manifest);
+  const update = normalizeUpdateConfig(m.update);
+
+  // Resolve the harness source: a caller-supplied --source dir (already materialized,
+  // e.g. by the update-harness skill) is used as-is; otherwise fetch on demand.
+  // Always cleaned up before returning.
+  let src;
+  if (opts.sourceDir) {
+    if (!fs.existsSync(path.join(opts.sourceDir, 'VERSION'))) {
+      return { error: 'invalid-source', message: `--source ${opts.sourceDir} is not a harness checkout (no VERSION file).` };
+    }
+    src = { dir: opts.sourceDir, cleanup: () => {}, ephemeral: false, channel: update.channel };
+  } else {
+    try {
+      src = resolveSource(update);
+    } catch (e) {
+      return { error: 'fetch-failed', message: e.message, channel: update.channel };
+    }
   }
 
-  const currentVersion = manifest.harnessVersion;
-  const latestVersion = fs.readFileSync(path.join(harnessRepoPath, 'VERSION'), 'utf8').trim();
-
-  let behind = 0;
-  let fetchError = null;
   try {
-    const fetchResult = spawnSync('git', ['fetch', '--quiet'], { cwd: harnessRepoPath, timeout: 15000, stdio: 'pipe' });
-    if (fetchResult.status !== 0) {
-      const stderr = (fetchResult.stderr || '').toString().trim();
-      if (stderr.includes('Could not resolve')) fetchError = 'offline';
-      else fetchError = stderr || 'fetch failed';
-    } else {
-      const trackingResult = spawnSync('git', ['rev-parse', '--abbrev-ref', '@{upstream}'], { cwd: harnessRepoPath, timeout: 5000, stdio: 'pipe' });
-      if (trackingResult.status === 0) {
-        const upstream = trackingResult.stdout.toString().trim();
-        const countResult = spawnSync('git', ['rev-list', '--count', `HEAD..${upstream}`], { cwd: harnessRepoPath, timeout: 5000, stdio: 'pipe' });
-        if (countResult.status === 0) behind = parseInt(countResult.stdout.toString().trim(), 10) || 0;
-      } else {
-        fetchError = 'no-upstream';
+    const currentVersion = m.harnessVersion;
+    const latestVersion = fs.readFileSync(path.join(src.dir, 'VERSION'), 'utf8').trim();
+    const updateAvailable = currentVersion !== latestVersion;
+
+    let changelogExcerpt = '';
+    const changelogPath = path.join(src.dir, 'CHANGELOG.md');
+    if (fs.existsSync(changelogPath)) {
+      const cl = fs.readFileSync(changelogPath, 'utf8');
+      const unreleasedMatch = cl.match(/## \[Unreleased\]\s*\n([\s\S]*?)(?=\n## \[|$)/i);
+      if (unreleasedMatch) changelogExcerpt = unreleasedMatch[1].trim().slice(0, 2000);
+    }
+
+    const orphans = [];
+    const sourceFiles = new Set();
+    for (const dir of ['skills', 'agents', 'hooks', 'rules']) {
+      const srcDir = path.join(src.dir, dir);
+      if (!fs.existsSync(srcDir)) continue;
+      const files = walk(srcDir, { match: () => true });
+      for (const f of files) sourceFiles.add(`${dir}/${path.relative(srcDir, f)}`);
+    }
+    for (const installed of (m.installedFiles || [])) {
+      if (installed === 'settings.json') continue;
+      if (installed.startsWith('trackers/')) continue;
+      if (installed.startsWith('code-platform/')) continue;
+      if (!sourceFiles.has(installed)) orphans.push(installed);
+    }
+
+    const subs = subsFromManifest(m, target);
+    const drifted = [];
+    for (const rel of (m.installedFiles || [])) {
+      if (rel === 'settings.json') continue;
+      const installedPath = path.join(target, rel);
+      const sourcePath = path.join(src.dir, rel);
+      if (!fs.existsSync(installedPath) || !fs.existsSync(sourcePath)) continue;
+      const installedHash = crypto.createHash('sha256').update(fs.readFileSync(installedPath)).digest('hex');
+      let sourceContent = fs.readFileSync(sourcePath);
+      if (/\.(md|sh|js|json|yaml|yml)$/i.test(rel)) {
+        let text = sourceContent.toString('utf8');
+        for (const [key, value] of subs) text = text.split(key).join(value);
+        sourceContent = Buffer.from(text, 'utf8');
       }
+      const sourceHash = crypto.createHash('sha256').update(sourceContent).digest('hex');
+      if (installedHash !== sourceHash) drifted.push(rel);
     }
-  } catch (e) {
-    fetchError = e.message;
-  }
 
-  let dirty = false;
-  const statusResult = spawnSync('git', ['status', '--porcelain'], { cwd: harnessRepoPath, timeout: 5000, stdio: 'pipe' });
-  if (statusResult.status === 0 && statusResult.stdout.toString().trim().length > 0) dirty = true;
-
-  let changelogExcerpt = '';
-  const changelogPath = path.join(harnessRepoPath, 'CHANGELOG.md');
-  if (fs.existsSync(changelogPath)) {
-    const cl = fs.readFileSync(changelogPath, 'utf8');
-    const unreleasedMatch = cl.match(/## \[Unreleased\]\s*\n([\s\S]*?)(?=\n## \[|$)/i);
-    if (unreleasedMatch) changelogExcerpt = unreleasedMatch[1].trim().slice(0, 2000);
+    return {
+      channel: src.channel, currentVersion, latestVersion, updateAvailable,
+      changelogExcerpt, orphans, drifted, manifestPath,
+    };
+  } finally {
+    src.cleanup();
   }
-
-  const orphans = [];
-  const sourceFiles = new Set();
-  for (const dir of ['skills', 'agents', 'hooks', 'rules']) {
-    const srcDir = path.join(harnessRepoPath, dir);
-    if (!fs.existsSync(srcDir)) continue;
-    const files = walk(srcDir, { match: () => true });
-    for (const f of files) sourceFiles.add(`${dir}/${path.relative(srcDir, f)}`);
-  }
-  for (const installed of (manifest.installedFiles || [])) {
-    if (installed === 'settings.json') continue;
-    if (installed.startsWith('trackers/')) continue;
-    if (!sourceFiles.has(installed)) orphans.push(installed);
-  }
-
-  const subs = subsFromManifest(manifest, target, harnessRepoPath);
-  const drifted = [];
-  for (const rel of (manifest.installedFiles || [])) {
-    if (rel === 'settings.json') continue;
-    const installedPath = path.join(target, rel);
-    const sourcePath = path.join(harnessRepoPath, rel);
-    if (!fs.existsSync(installedPath) || !fs.existsSync(sourcePath)) continue;
-    const installedHash = crypto.createHash('sha256').update(fs.readFileSync(installedPath)).digest('hex');
-    let sourceContent = fs.readFileSync(sourcePath);
-    if (/\.(md|sh|js|json|yaml|yml)$/i.test(rel)) {
-      let text = sourceContent.toString('utf8');
-      for (const [key, value] of subs) text = text.split(key).join(value);
-      sourceContent = Buffer.from(text, 'utf8');
-    }
-    const sourceHash = crypto.createHash('sha256').update(sourceContent).digest('hex');
-    if (installedHash !== sourceHash) drifted.push(rel);
-  }
-
-  return {
-    currentVersion, latestVersion, behind, dirty,
-    fetchError, changelogExcerpt, orphans, drifted, manifestPath,
-  };
 }
 
 // D22-D24: Handle the first update crossing into the modes era.
@@ -372,7 +372,7 @@ function handleModeCrossing(manifest, target, nonInteractive) {
   } catch { /* non-critical — skip if git not available */ }
 }
 
-function runUpdate(target, { repoDir, cliArgs = [] }) {
+function runUpdate(target, { cliArgs = [], sourceDir = null, channelOverride = null } = {}) {
   const manifestPath = path.join(target, '.harness-manifest.json');
   if (!fs.existsSync(manifestPath)) {
     console.error('  Error: No .harness-manifest.json found at ' + target);
@@ -388,21 +388,50 @@ function runUpdate(target, { repoDir, cliArgs = [] }) {
     process.exit(1);
   }
 
-  const harnessRepoPath = (manifest.answers && manifest.answers.harnessRepoPath) || repoDir;
-  if (!fs.existsSync(harnessRepoPath) || !fs.existsSync(path.join(harnessRepoPath, 'VERSION'))) {
-    console.error(`  Error: Harness clone not found at ${harnessRepoPath}`);
-    console.error('  Git clone it and re-run, or update answers.harnessRepoPath in the manifest.');
-    process.exit(1);
+  // Migrate the legacy persistent-clone shape; persisted when we write the manifest below.
+  const migration = migrateUpdateConfig(manifest);
+  const m = migration.manifest;
+  if (migration.changed) {
+    console.log('  Migrated update config → fetch-on-demand channel "latest" (no local clone needed).');
   }
+  // A --pin / --latest / --local flag re-points the channel as part of this update.
+  if (channelOverride) {
+    m.update = channelOverride;
+    console.log(`  Update channel set to "${channelOverride.channel}"${channelOverride.channel === 'pinned' ? ` (${channelOverride.pinnedVersion})` : ''}.`);
+  }
+  const update = normalizeUpdateConfig(m.update);
 
+  // Resolve the harness source BEFORE any mutation, so a fetch failure aborts before
+  // we touch the install. A caller-supplied --source dir is used as-is (no fetch,
+  // no cleanup); otherwise fetch on demand and remove it in the finally.
+  let src;
+  if (sourceDir) {
+    if (!fs.existsSync(path.join(sourceDir, 'VERSION'))) {
+      console.error(`  Error: --source ${sourceDir} is not a harness checkout (no VERSION file).`);
+      process.exit(1);
+    }
+    src = { dir: sourceDir, cleanup: () => {}, ephemeral: false, channel: update.channel };
+  } else {
+    try {
+      src = resolveSource(update);
+    } catch (e) {
+      console.error('  Error: ' + e.message);
+      process.exit(1);
+    }
+  }
+  console.log(src.ephemeral
+    ? `  Fetched harness source (channel: ${src.channel})`
+    : `  Using local harness source: ${src.dir}`);
+
+  try {
   const backupsDir = path.join(os.homedir(), '.claude', '.harness-backups');
   fs.mkdirSync(backupsDir, { recursive: true });
   const stamp = new Date().toISOString().replace(/[-:T.]/g, '').slice(0, 15);
   const snapshotDir = path.join(backupsDir, stamp);
   fs.mkdirSync(snapshotDir, { recursive: true });
   for (const d of ['skills', 'agents', 'hooks', 'rules', 'trackers']) {
-    const src = path.join(target, d);
-    if (fs.existsSync(src)) fs.cpSync(src, path.join(snapshotDir, d), { recursive: true });
+    const s = path.join(target, d);
+    if (fs.existsSync(s)) fs.cpSync(s, path.join(snapshotDir, d), { recursive: true });
   }
   const settingsFile = path.join(target, 'settings.json');
   if (fs.existsSync(settingsFile)) fs.copyFileSync(settingsFile, path.join(snapshotDir, 'settings.json'));
@@ -415,55 +444,27 @@ function runUpdate(target, { repoDir, cliArgs = [] }) {
     fs.rmSync(path.join(backupsDir, old), { recursive: true, force: true });
   }
 
-  const skipPull = cliArgs.includes('--skip-pull');
-  if (!skipPull) {
-    const diffResult = spawnSync('git', ['diff', '--name-only', 'HEAD'], { cwd: harnessRepoPath, timeout: 5000, stdio: 'pipe' });
-    const stagedResult = spawnSync('git', ['diff', '--name-only', '--cached'], { cwd: harnessRepoPath, timeout: 5000, stdio: 'pipe' });
-    const hasDirtyTracked = (diffResult.status === 0 && diffResult.stdout.toString().trim().length > 0)
-      || (stagedResult.status === 0 && stagedResult.stdout.toString().trim().length > 0);
-    if (hasDirtyTracked) {
-      console.error('  Error: Harness clone has uncommitted changes to tracked files.');
-      console.error(`  cd ${harnessRepoPath} && git stash`);
-      console.error(`  Then re-run the update.`);
-      console.error(`  Snapshot at: ${snapshotDir}`);
-      process.exit(1);
-    }
-
-    const pullResult = spawnSync('git', ['pull', '--ff-only'], { cwd: harnessRepoPath, timeout: 30000, stdio: 'pipe' });
-    if (pullResult.status !== 0) {
-      const stderr = (pullResult.stderr || '').toString().trim();
-      console.error('  Error: git pull --ff-only failed.');
-      console.error(`  ${stderr}`);
-      console.error(`  Resolve manually: cd ${harnessRepoPath} && git pull --ff-only`);
-      console.error(`  Snapshot at: ${snapshotDir}`);
-      process.exit(1);
-    }
-    const pullOut = (pullResult.stdout || '').toString().trim();
-    if (pullOut.includes('Already up to date')) {
-      console.log('  Already up to date.');
-    } else {
-      console.log(`  Pulled: ${pullOut.split('\n')[0]}`);
-    }
-  }
+  // No git pull here: a fetched shallow clone is already at the target ref, and the
+  // local channel intentionally uses the working tree as-is (dogfood development).
 
   // ── Mode crossing (D22-D24): first update into the modes era ──────────────
   const nonInteractive = cliArgs.includes('--yes') || cliArgs.includes('-y');
-  if (!('trackerMirror' in manifest)) {
-    handleModeCrossing(manifest, target, nonInteractive);
+  if (!('trackerMirror' in m)) {
+    handleModeCrossing(m, target, nonInteractive);
   }
 
   const installedFiles = [];
-  const { workflowPack, tracker } = manifest;
-  const codePlatform = manifest.codePlatform || 'none';
+  const { workflowPack, tracker } = m;
+  const codePlatform = m.codePlatform || 'none';
   for (const d of ['skills', 'agents', 'hooks', 'rules', 'trackers/active', 'code-platform/active']) {
     fs.mkdirSync(path.join(target, d), { recursive: true });
   }
 
-  installedFiles.push(...copyDirsWithLog(path.join(harnessRepoPath, 'skills'), path.join(target, 'skills'), 'skills'));
-  installedFiles.push(...copyGlob(path.join(harnessRepoPath, 'trackers', tracker || 'github'), path.join(target, 'trackers/active'), /\.sh$/, 'trackers/active'));
+  installedFiles.push(...copyDirsWithLog(path.join(src.dir, 'skills'), path.join(target, 'skills'), 'skills'));
+  installedFiles.push(...copyGlob(path.join(src.dir, 'trackers', tracker || 'github'), path.join(target, 'trackers/active'), /\.sh$/, 'trackers/active'));
   chmodExecutables(path.join(target, 'trackers/active'));
 
-  const trackerLibSrc = path.join(harnessRepoPath, 'trackers/lib');
+  const trackerLibSrc = path.join(src.dir, 'trackers/lib');
   if (fs.existsSync(trackerLibSrc)) {
     fs.mkdirSync(path.join(target, 'trackers/lib'), { recursive: true });
     installedFiles.push(...copyGlob(trackerLibSrc, path.join(target, 'trackers/lib'), /\.sh$/, 'trackers/lib'));
@@ -480,38 +481,38 @@ function runUpdate(target, { repoDir, cliArgs = [] }) {
   }
 
   // Copy code-platform adapter
-  const codePlatformSrcDir = path.join(harnessRepoPath, 'code-platform', codePlatform);
+  const codePlatformSrcDir = path.join(src.dir, 'code-platform', codePlatform);
   if (fs.existsSync(codePlatformSrcDir)) {
     installedFiles.push(...copyGlob(codePlatformSrcDir, path.join(target, 'code-platform/active'), /\.sh$/, 'code-platform/active'));
     chmodExecutables(path.join(target, 'code-platform/active'));
   }
 
-  const codePlatformLibSrc = path.join(harnessRepoPath, 'code-platform/lib');
+  const codePlatformLibSrc = path.join(src.dir, 'code-platform/lib');
   if (fs.existsSync(codePlatformLibSrc)) {
     fs.mkdirSync(path.join(target, 'code-platform/lib'), { recursive: true });
     installedFiles.push(...copyGlob(codePlatformLibSrc, path.join(target, 'code-platform/lib'), /\.sh$/, 'code-platform/lib'));
   }
 
   const agentSkip = workflowPack === 'solo' ? ENTERPRISE_ONLY_AGENTS : null;
-  installedFiles.push(...copyFilesWithLog(path.join(harnessRepoPath, 'agents'), path.join(target, 'agents'), /\.md$/, 'agents', false, agentSkip));
-  installedFiles.push(...copyFilesWithLog(path.join(harnessRepoPath, 'hooks'), path.join(target, 'hooks'), null, 'hooks', true));
+  installedFiles.push(...copyFilesWithLog(path.join(src.dir, 'agents'), path.join(target, 'agents'), /\.md$/, 'agents', false, agentSkip));
+  installedFiles.push(...copyFilesWithLog(path.join(src.dir, 'hooks'), path.join(target, 'hooks'), null, 'hooks', true));
 
-  const hooksLibSrc = path.join(harnessRepoPath, 'hooks/lib');
+  const hooksLibSrc = path.join(src.dir, 'hooks/lib');
   if (fs.existsSync(hooksLibSrc)) {
     fs.mkdirSync(path.join(target, 'hooks/lib'), { recursive: true });
     installedFiles.push(...copyGlob(hooksLibSrc, path.join(target, 'hooks/lib'), /\.js$/, 'hooks/lib'));
   }
 
-  installedFiles.push(...copyFilesWithLog(path.join(harnessRepoPath, 'rules'), path.join(target, 'rules'), /\.md$/, 'rules'));
+  installedFiles.push(...copyFilesWithLog(path.join(src.dir, 'rules'), path.join(target, 'rules'), /\.md$/, 'rules'));
 
-  const mode = manifest.installMode || 'project';
-  const substitutions = subsFromManifest(manifest, target, harnessRepoPath);
+  const mode = m.installMode || 'project';
+  const substitutions = subsFromManifest(m, target);
   const sedDirs = ['skills', 'agents', 'hooks', 'rules', 'trackers', 'code-platform']
     .map((d) => path.join(target, d))
     .filter((d) => fs.existsSync(d));
   for (const dir of sedDirs) substituteInTree(dir, substitutions);
 
-  const oldFiles = new Set(manifest.installedFiles || []);
+  const oldFiles = new Set(m.installedFiles || []);
   const newFiles = new Set(installedFiles);
   let orphansRemoved = 0;
   for (const old of oldFiles) {
@@ -534,7 +535,7 @@ function runUpdate(target, { repoDir, cliArgs = [] }) {
     : 'SESSION START: Before doing anything else — read tasks/lessons.md, todo.md, pr-queue.md, and flags-and-notes.md';
   const newHarnessSettings = buildSettings({
     hooksUnix, workflowPack: workflowPack || 'solo', sessionStartMsg,
-    workRoot: manifest.answers?.workRoot || '', isGlobal: mode === 'global',
+    workRoot: m.answers?.workRoot || '', isGlobal: mode === 'global',
   });
 
   if (fs.existsSync(settingsFile)) {
@@ -552,26 +553,29 @@ function runUpdate(target, { repoDir, cliArgs = [] }) {
 
   verifyInstall(target, sedDirs, workflowPack);
 
-  const newVersion = fs.readFileSync(path.join(harnessRepoPath, 'VERSION'), 'utf8').trim();
-  const updatedManifest = {
-    ...manifest,
-    harnessVersion: newVersion,
-    installedFiles: installedFiles.sort(),
-    updatedAt: new Date().toISOString(),
-  };
-  fs.writeFileSync(manifestPath, JSON.stringify(updatedManifest, null, 2) + '\n', 'utf8');
+    const newVersion = fs.readFileSync(path.join(src.dir, 'VERSION'), 'utf8').trim();
+    const updatedManifest = {
+      ...m,
+      harnessVersion: newVersion,
+      installedFiles: installedFiles.sort(),
+      updatedAt: new Date().toISOString(),
+    };
+    fs.writeFileSync(manifestPath, JSON.stringify(updatedManifest, null, 2) + '\n', 'utf8');
 
-  console.log(`\n  Updated: ${manifest.harnessVersion} → ${newVersion}`);
-  console.log(`  Restore: cp -r "${snapshotDir}/"* "${target}/"`);
+    console.log(`\n  Updated: ${m.harnessVersion} → ${newVersion}`);
+    console.log(`  Restore: cp -r "${snapshotDir}/"* "${target}/"`);
 
-  if (!updatedManifest.tracker) {
-    console.log('');
-    console.log('  ⚠ Tracker not configured for this project.');
-    console.log('  Set it with: node install/install.js --switch-tracker <github|todoist|ado> --project ' + path.dirname(target));
+    if (!updatedManifest.tracker) {
+      console.log('');
+      console.log('  ⚠ Tracker not configured for this project.');
+      console.log('  Set it with: node install/install.js --switch-tracker <github|todoist|ado> --project ' + path.dirname(target));
+    }
+  } finally {
+    src.cleanup();
   }
 }
 
-function runSwitchTracker(target, tracker, repoDir) {
+function runSwitchTracker(target, tracker) {
   const VALID_TRACKERS = new Set(['github', 'todoist', 'ado', 'local', 'none']);
   if (!VALID_TRACKERS.has(tracker)) {
     console.error(`  Error: Invalid tracker "${tracker}". Choose: github, todoist, ado, local, none`);
@@ -590,39 +594,46 @@ function runSwitchTracker(target, tracker, repoDir) {
     process.exit(1);
   }
 
-  const harnessRepoPath = (manifest.answers && manifest.answers.harnessRepoPath) || repoDir;
-  const oldTracker = manifest.tracker || '(none)';
+  // Migrate legacy shape so the tracker switch also persists the fetch-on-demand config.
+  const { manifest: m } = migrateUpdateConfig(manifest);
+  const oldTracker = m.tracker || '(none)';
 
   if (tracker !== 'none') {
-    const trackerSrcDir = path.join(harnessRepoPath, 'trackers', tracker);
-    if (!fs.existsSync(trackerSrcDir)) {
-      console.error(`  Error: Tracker adapter source not found at ${trackerSrcDir}`);
-      process.exit(1);
-    }
+    // Adapter scripts come from the harness source, fetched on demand.
+    const src = resolveSource(normalizeUpdateConfig(m.update));
+    try {
+      const trackerSrcDir = path.join(src.dir, 'trackers', tracker);
+      if (!fs.existsSync(trackerSrcDir)) {
+        console.error(`  Error: Tracker adapter source not found at ${trackerSrcDir}`);
+        process.exit(1);
+      }
 
-    const activeDir = path.join(target, 'trackers', 'active');
-    fs.mkdirSync(activeDir, { recursive: true });
-    for (const f of fs.readdirSync(activeDir)) {
-      if (f.endsWith('.sh')) fs.rmSync(path.join(activeDir, f), { force: true });
-    }
+      const activeDir = path.join(target, 'trackers', 'active');
+      fs.mkdirSync(activeDir, { recursive: true });
+      for (const f of fs.readdirSync(activeDir)) {
+        if (f.endsWith('.sh')) fs.rmSync(path.join(activeDir, f), { force: true });
+      }
 
-    copyGlob(trackerSrcDir, activeDir, /\.sh$/, 'trackers/active');
-    chmodExecutables(activeDir);
-    console.log(`  Copied ${tracker} adapter scripts to trackers/active/`);
+      copyGlob(trackerSrcDir, activeDir, /\.sh$/, 'trackers/active');
+      chmodExecutables(activeDir);
+      console.log(`  Copied ${tracker} adapter scripts to trackers/active/`);
 
-    const libSrc = path.join(harnessRepoPath, 'trackers', 'lib');
-    if (fs.existsSync(libSrc)) {
-      const libDest = path.join(target, 'trackers', 'lib');
-      fs.mkdirSync(libDest, { recursive: true });
-      copyGlob(libSrc, libDest, /\.sh$/);
+      const libSrc = path.join(src.dir, 'trackers', 'lib');
+      if (fs.existsSync(libSrc)) {
+        const libDest = path.join(target, 'trackers', 'lib');
+        fs.mkdirSync(libDest, { recursive: true });
+        copyGlob(libSrc, libDest, /\.sh$/);
+      }
+    } finally {
+      src.cleanup();
     }
   }
 
-  manifest.tracker = tracker === 'none' ? null : tracker;
+  m.tracker = tracker === 'none' ? null : tracker;
   // Switching to local clears mirror; switching to external preserves it
-  if (tracker === 'local') manifest.trackerMirror = false;
-  manifest.updatedAt = new Date().toISOString();
-  fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n', 'utf8');
+  if (tracker === 'local') m.trackerMirror = false;
+  m.updatedAt = new Date().toISOString();
+  fs.writeFileSync(manifestPath, JSON.stringify(m, null, 2) + '\n', 'utf8');
 
   console.log(`  Tracker switched: ${oldTracker} → ${tracker}`);
 
@@ -655,7 +666,7 @@ function runSwitchTracker(target, tracker, repoDir) {
   }
 }
 
-function backfillManifest(target, opts = {}, repoDir) {
+function backfillManifest(target, opts = {}) {
   const agentsDir = path.join(target, 'agents');
   let workflowPack = 'solo';
   if (fs.existsSync(agentsDir)) {
@@ -702,7 +713,6 @@ function backfillManifest(target, opts = {}, repoDir) {
   if (fs.existsSync(path.join(target, 'settings.json'))) installedFiles.push('settings.json');
 
   const harnessVersion = opts.harnessVersion || 'unknown';
-  const harnessRepoPath = opts.harnessRepoPath || repoDir;
   const prdMode = opts.prdMode || 'file';
 
   const now = new Date().toISOString();
@@ -715,9 +725,9 @@ function backfillManifest(target, opts = {}, repoDir) {
     answers: {
       userName: 'YOUR_NAME',
       projectName: 'YOUR_PROJECT_NAME',
-      harnessRepoPath,
       ...(opts.answers || {}),
     },
+    update: opts.update || { repoUrl: DEFAULT_REPO_URL, channel: 'latest', pinnedVersion: null, localPath: null },
     installedFiles: installedFiles.sort(),
     now,
   });

--- a/skills/update-harness/SKILL.md
+++ b/skills/update-harness/SKILL.md
@@ -1,9 +1,14 @@
 ---
 name: update-harness
-description: Check for and apply updates to your claude-code-harness installation. Resolves target (project/global/both), checks for new versions, shows changelog, and applies updates with human confirmation. Usage: /update-harness [--global|--project]
+description: Check for and apply updates to your claude-code-harness installation. Resolves target (project/global/both), fetches the harness source on demand, shows the changelog, and applies updates with human confirmation. Usage: /update-harness [--global|--project] [--pin <version>|--latest|--local <path>]
 ---
 
-You are the harness update orchestrator. Your job is to check for available updates to the user's claude-code-harness installation and apply them safely with the user's confirmation.
+You are the harness update orchestrator. Your job is to check for available updates to the user's
+claude-code-harness installation and apply them safely with the user's confirmation.
+
+**The harness no longer keeps a persistent local clone.** The source is fetched on demand from the
+manifest's `update` config, used, and discarded. There is nothing to keep in the project, and nothing
+to point a stale path at.
 
 ---
 
@@ -22,94 +27,121 @@ Resolution rules:
 - `--global` flag in `$ARGUMENTS` → skip detection, target global
 - `--project` flag in `$ARGUMENTS` → skip detection, target project
 
-For each target, read `.harness-manifest.json` and extract `answers.harnessRepoPath`.
+For each target, read `.harness-manifest.json` → the **`update`** block: `{ repoUrl, channel, pinnedVersion, localPath }`.
+- `channel: "latest"` (default) — newest `main`
+- `channel: "pinned"` — the tag in `pinnedVersion`
+- `channel: "local"` — a local clone at `localPath` (harness development / offline)
+
+If the manifest has no `update` block (a pre-fetch-on-demand install), that's fine — the installer
+migrates it automatically on the first `--update`. Treat it as channel `latest`.
 
 ---
 
-## Step 2 — Precondition checks
+## Step 2 — Apply any channel change from `$ARGUMENTS`
 
-For each target:
+If the user passed a channel flag, honor it — it re-points the install as part of this update:
+- `--pin <version>` → channel becomes `pinned` at that version
+- `--latest` → channel becomes `latest`
+- `--local <path>` → channel becomes `local` at that path
 
-1. Verify the harness clone exists at `answers.harnessRepoPath`. If missing:
-   ```
-   Error: Harness source not found at <path>.
-   Fix: git clone <repo-url> <path>
-   Or update the path: edit <target>/.harness-manifest.json → answers.harnessRepoPath
-   ```
-   **Stop.** Do not proceed without the clone.
-
-2. If the manifest is missing (no-manifest case), route to the Legacy Backfill procedure.
+Carry the flag through to the `--update` command in Step 5 (the installer persists it). Use the
+**resulting** channel to materialize the source in Step 3.
 
 ---
 
-## Step 3 — Check for updates
+## Step 3 — Materialize the harness source once
 
-Run the installer's `--check` mode:
+You need the installer (`install/install.js`) and the source tree to diff against. Obtain it **once**,
+then reuse it for both check and update via `--source`.
+
+- **channel `local`** → source dir = `localPath`. Verify `<localPath>/install/install.js` and
+  `<localPath>/VERSION` exist. If not, tell the user their `localPath` is wrong and stop.
+- **channel `latest`** → shallow-clone into a temp dir:
+  ```bash
+  git clone --depth 1 "<repoUrl>" "<tempDir>"
+  ```
+- **channel `pinned`** → shallow-clone the tag (try the version verbatim, then a `v`-prefixed form):
+  ```bash
+  git clone --depth 1 --branch "<pinnedVersion>" "<repoUrl>" "<tempDir>"
+  ```
+
+Use a temp dir under the system temp location (e.g. `mktemp -d`). If the clone fails (offline, bad
+URL, or unknown tag), report the exact error and stop — nothing has been mutated.
+
+**Remember the source dir** — you pass it as `--source` below and delete it (if it's a temp clone) in Step 7.
+
+---
+
+## Step 4 — Check for updates
+
+Run the installer from the materialized source, reusing it via `--source`:
 
 ```bash
-node "<harnessRepoPath>/install/install.js" --check --project "<projectDir>"
+node "<sourceDir>/install/install.js" --check --project "<projectDir>" --source "<sourceDir>"
 # or --global for global installs
 ```
 
-Parse the JSON output. Narrate the result:
+Parse the JSON output. Handle `error` first if present (`no-manifest`, `invalid-manifest`,
+`invalid-source`, `fetch-failed`) — narrate it and stop.
 
-- **Version**: `<currentVersion>` → `<latestVersion>` (`<behind>` commits behind)
-- **Drifted files** (if any): `<drifted.length>` installed file(s) differ from the harness source. List the first 10.
+Otherwise narrate the result:
+- **Version**: `<currentVersion>` → `<latestVersion>`  (channel: `<channel>`)
+- **Update available**: `<updateAvailable>`
+- **Drifted files** (if any): `<drifted.length>` installed file(s) differ from the source. List the first 10.
 - **Changelog** (if any): show the excerpt
 - **Orphaned files** (if any): list them
-- **Dirty clone** warning (if `dirty` is true)
-- **Fetch error** (if `fetchError` is set): narrate the specific error
 
-If `behind === 0` and `currentVersion === latestVersion` **and** `drifted.length === 0`:
+If `updateAvailable === false` **and** `drifted.length === 0`:
 ```
 Your harness is up to date (v<version>).
 ```
-**Stop** unless the user explicitly asks to re-apply.
+Clean up the temp source (Step 7) and **stop** unless the user explicitly asks to re-apply.
 
-If `drifted.length > 0` even when version/behind look current, there are source changes that haven't been installed yet. Proceed to the human gate (Step 4) and show the drifted file count.
+If `drifted.length > 0` even when the version matches, there are source changes not yet installed.
+Proceed to the human gate and show the drifted file count.
 
 ---
 
-## Step 4 — Human gate
+## Step 5 — Human gate
 
 **NEVER mutate files before this step.** Show the user what will happen:
 
 ```
 Ready to update claude-code-harness:
   Version:  <current> → <latest>
+  Channel:  <channel>
   Target:   <target path>
-  Changes:  <behind> commits
   Drifted:  <count> file(s) differ from source
   Orphans:  <count> file(s) will be removed
 
 Proceed? [y/N]
 ```
 
-Wait for explicit confirmation. If denied, stop.
+Wait for explicit confirmation. If denied, clean up the temp source (Step 7) and stop.
 
 ---
 
-## Step 5 — Apply the update
+## Step 6 — Apply the update
 
-Run the installer's `--update` mode:
+Run the installer's `--update` mode against the same source, plus any channel flag from Step 2:
 
 ```bash
-node "<harnessRepoPath>/install/install.js" --update --project "<projectDir>"
+node "<sourceDir>/install/install.js" --update --project "<projectDir>" --source "<sourceDir>" --yes
+# add --pin <version> / --latest / --local <path> if the user asked to change channel
 # or --global for global installs
 ```
 
 Narrate each step as it happens:
 1. Snapshot created at `~/.claude/.harness-backups/<timestamp>/`
-2. Git pull result (or "already up to date")
-3. Files copied/updated
-4. Orphans removed
-5. Settings reconciled
-6. Verification result
-7. Manifest updated
+2. Files copied/updated
+3. Orphans removed
+4. Settings reconciled
+5. Verification result
+6. Manifest updated (version + update config)
 
 ---
 
-## Step 5b — Check tracker configuration
+## Step 6b — Check tracker configuration
 
 After the update completes, check if `tracker` is set in the manifest:
 
@@ -123,9 +155,9 @@ After the update completes, check if `tracker` is set in the manifest:
      3) Azure DevOps
      4) None (local task files only)
    ```
-   On answer, run:
+   On answer, run (reusing the same source):
    ```bash
-   node "<harnessRepoPath>/install/install.js" --switch-tracker <choice> --project "<projectDir>"
+   node "<sourceDir>/install/install.js" --switch-tracker <choice> --project "<projectDir>"
    ```
 3. If set but adapter scripts don't match (verify by checking script contents):
    ```
@@ -135,52 +167,46 @@ After the update completes, check if `tracker` is set in the manifest:
 
 ---
 
-## Step 6 — Report result
+## Step 7 — Clean up and report
 
-After completion, report:
+If you created a temp clone in Step 3, delete it now (channel `local` sources are never deleted).
+
+Then report:
 
 ```
-Update complete: v<old> → v<new>
+Update complete: v<old> → v<new>  (channel: <channel>)
 Tracker: <tracker>
 
 To restore the previous version:
   cp -r "<snapshot-path>/"* "<target>/"
 ```
 
-If updating **both** targets, repeat steps 3-6 for the second target.
+If updating **both** targets, repeat steps 3-7 for the second target (each gets its own source fetch,
+or reuse one temp clone if the channels match).
 
 ---
 
 ## Legacy Backfill
 
-When no manifest exists (pre-manifest install), create one by reverse-detecting the install configuration:
+When no manifest exists (pre-manifest install), create one by reverse-detecting the install configuration.
+You still need a source for this — materialize one per Step 3 using channel `latest` (or ask the user for
+a `--local` path if they have a clone), and run:
 
-1. **Detect workflowPack**: Check if enterprise-only agents exist (e.g., `story-understand-agent.md`). If present → `enterprise`. Otherwise → `solo`.
+```bash
+node "<sourceDir>/install/install.js" --backfill --project "<projectDir>"
+```
 
-2. **Detect tracker**: Read the tracker adapter scripts in `<target>/trackers/active/`:
-   - If scripts contain `az boards` → `ado`
-   - If scripts contain `td ` (Todoist CLI calls) → `todoist`
-   - Otherwise → `github`
+The backfill:
+1. **Detects workflowPack** — enterprise-only agents present → `enterprise`, else `solo`.
+2. **Detects tracker** — from the adapter scripts in `<target>/trackers/active/` (`az boards` → ado,
+   `td ` → todoist, else github).
+3. **Writes the manifest** — including a default `update` block (channel `latest`). No clone path is
+   recorded; future updates fetch on demand.
 
-3. **Detect prdMode**: ASK the user — this cannot be reliably auto-detected:
-   ```
-   Where do your PRDs live?
-     1) File in repo (PRD.md)
-     2) Tracker issue
-     3) Both — file canonical
-     4) Both — tracker canonical
-   ```
-
-4. **Reconstruct installedFiles**: Walk the target's `skills/`, `agents/`, `hooks/`, `rules/`, `trackers/` directories and list all files.
-
-5. **Read harnessRepoPath**: ASK the user for the path to their harness clone if not obvious.
-
-6. **Write manifest**: Use the detected values to write `.harness-manifest.json`.
-
-Narrate the entire process:
+Narrate the process:
 ```
 You installed the harness before manifests were added.
-I'll ask a couple of questions to create one — future updates will be silent.
+I'll create one — future updates fetch the latest source automatically, no local clone needed.
 ```
 
-After backfill, proceed with the normal update flow (Step 3 onwards).
+After backfill, proceed with the normal update flow (Step 3 onwards). Then clean up the temp source.


### PR DESCRIPTION
## What

Replaces the persistent-clone update model with **fetch-on-demand**. `/update-harness` no longer requires a local `claude-code-harness` clone to sit next to the project — it resolves the harness source on demand from a new `update` block in `.harness-manifest.json`, uses it, and discards it.

## Update channels

- `latest` (default) — newest `main`
- `pinned` — a version tag you opt into bumping (`--pin <version>`)
- `local` — a clone you point at, for harness development / offline (`--local <path>`)

Channel flags work at install time and with `--update` to re-point a live install. `--check`/`--update` also accept `--source <dir>` to reuse an already-fetched checkout (used by the update-harness skill to fetch once).

## Migration

Manifest `schemaVersion` → 2. The old `answers.harnessRepoPath` clone pointer is replaced by the `update` block. Existing installs migrate automatically on their first `--update` (pointer dropped, channel defaults to `latest`).

## Files

- new `install/lib/source.js` — `resolveSource`, `normalizeUpdateConfig`, `migrateUpdateConfig` (injectable git → network-free unit tests)
- `install/lib/updater.js` — `runCheck`/`runUpdate`/`runSwitchTracker`/`backfillManifest` read a resolved source; removed git-pull/dirty-clone handling
- `install/install.js` — dropped the harness-repo-path prompt/flag; added `--pin`/`--latest`/`--local`/`--repo-url`/`--source`
- rewrote `skills/update-harness/SKILL.md`; updated README, CONFIGURE, CHANGELOG

## Tests

411 tests green (includes new `install/__tests__/source.test.js` and offline integration coverage for the `local`/`--source` paths and channel-switch on `--update`). Validated end-to-end: offline local channel, live GitHub shallow-clone fetch, legacy-manifest migration, and the fetch-once/`--source`-reuse flow with no temp-dir leaks.
