### PR TITLE
feat(hooks): prompt for git commit/push instead of hard-blocking

### DIFF
--- a/hooks/__tests__/safety-check.test.js
+++ b/hooks/__tests__/safety-check.test.js
@@ -26,9 +26,6 @@ function write(filePath, content) { return runHook('Write', { file_path: filePat
 // ── Bash rule positive cases (each rule must fire) ────────────────────
 
 const BASH_DENY_CASES = [
-  // Git oversight
-  { name: 'git commit', cmd: 'git commit -m "x"', expectReason: /git commit/ },
-  { name: 'git push', cmd: 'git push origin main', expectReason: /git push/ },
   // Git destructive
   { name: 'git reset --hard', cmd: 'git reset --hard HEAD~1', expectReason: /reset --hard/ },
   { name: 'git checkout .', cmd: 'git checkout .', expectReason: /checkout \./ },
@@ -88,6 +85,33 @@ for (const { name, cmd, expectReason } of BASH_DENY_CASES) {
     assert.match(r.json.reason, expectReason);
   });
 }
+
+// ── Git oversight: ask (prompt) rather than hard-deny ─────────────────
+
+const BASH_ASK_CASES = [
+  { name: 'git commit', cmd: 'git commit -m "x"', expectReason: /git commit/ },
+  { name: 'git push', cmd: 'git push origin main', expectReason: /git push/ },
+];
+
+for (const { name, cmd, expectReason } of BASH_ASK_CASES) {
+  test(`Bash_${name.replace(/\s+/g, '_')}_AsksExit0`, () => {
+    const r = bash(cmd);
+    assert.equal(r.exitCode, 0, `expected exit 0 (ask), got ${r.exitCode}: ${r.stdout}`);
+    const out = r.json && r.json.hookSpecificOutput;
+    assert.ok(out, `expected hookSpecificOutput, got ${r.stdout}`);
+    assert.equal(out.permissionDecision, 'ask');
+    assert.match(out.permissionDecisionReason, expectReason);
+  });
+}
+
+// Destructive denials must win over ask prompts: a command that both commits and
+// deletes must be hard-denied, never merely prompted.
+test('Bash_GitCommitAndRmRf_DeniedNotAsked', () => {
+  const r = bash('git commit -m x && rm -rf /tmp/foo');
+  assert.equal(r.exitCode, 2, `expected exit 2 (deny), got ${r.exitCode}: ${r.stdout}`);
+  assert.equal(r.json.decision, 'deny');
+  assert.match(r.json.reason, /rm -rf/);
+});
 
 // ── Bash false-positive negatives (these must NOT fire) ───────────────
 

--- a/hooks/lib/hook-io.js
+++ b/hooks/lib/hook-io.js
@@ -134,11 +134,27 @@ function pruneOldRotations(filePath, keep) {
   } catch { /* prune is best-effort */ }
 }
 
-// PreToolUse deny — exit 2 + JSON on stdout. Prevents the tool call.
+// PreToolUse deny — exit 2 + JSON on stdout. Prevents the tool call outright.
 function deny(reason, rule) {
   recordMetric({ decision: 'deny', rule });
   process.stdout.write(JSON.stringify({ decision: 'deny', reason }));
   process.exit(2);
+}
+
+// PreToolUse ask — routes the tool call to the user's approval prompt instead of
+// hard-blocking it. Use for oversight gates (e.g. git commit/push) where the intent
+// is "a human must sign off", not "never allowed". Exit 0; the runtime shows the
+// prompt and the user allows or denies.
+function ask(reason, rule) {
+  recordMetric({ decision: 'ask', rule });
+  process.stdout.write(JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'ask',
+      permissionDecisionReason: reason,
+    },
+  }));
+  process.exit(0);
 }
 
 // PostToolUse block — tells Claude to stop and address before further work.
@@ -218,6 +234,7 @@ function runHook(hookName, fn) {
 module.exports = {
   readStdinJson,
   deny,
+  ask,
   blockPost,
   injectContext,
   ok,

--- a/hooks/safety-check.js
+++ b/hooks/safety-check.js
@@ -10,13 +10,16 @@
 //   - BASH_RULES: applied to Bash command strings
 //   - WRITE_RULES: applied to Write file content + path (skipped for docs)
 
-const { readStdinJson, deny, ok, runHook } = require('./lib/hook-io');
+const { readStdinJson, deny, ask, ok, runHook } = require('./lib/hook-io');
 
 // ── Bash command rules ────────────────────────────────────────────────
+// action: 'ask' routes the command to the user's approval prompt (oversight —
+// the human signs off in the moment). Everything else hard-denies (destructive,
+// never allowed). Destructive denials always win over ask prompts (see checkRules).
 const BASH_RULES = [
-  // 1. Git: commit and push (user wants oversight)
-  { id: 'git-commit', re: /\bgit\s+commit\b/i, reason: 'git commit — needs your approval' },
-  { id: 'git-push',   re: /\bgit\s+push\b/i,   reason: 'git push — needs your approval' },
+  // 1. Git: commit and push — human oversight, not a ban. Prompt for approval.
+  { id: 'git-commit', re: /\bgit\s+commit\b/i, action: 'ask', reason: 'git commit — approve to let Claude run it' },
+  { id: 'git-push',   re: /\bgit\s+push\b/i,   action: 'ask', reason: 'git push — approve to let Claude run it' },
 
   // 2. Git: destructive operations
   { id: 'git-reset-hard',  re: /\bgit\s+reset\s+--hard\b/i,            reason: 'git reset --hard — destroys uncommitted work' },
@@ -106,8 +109,16 @@ function looksLikeHardcodedSecret(content) {
 }
 
 function checkRules(rules, text) {
+  // Destructive denials take precedence: a command that both matches an ask rule
+  // and a deny rule (e.g. "git commit && rm -rf") must be hard-blocked, not merely
+  // prompted. So run all deny rules first, then the ask prompts.
   for (const rule of rules) {
+    if (rule.action === 'ask') continue;
     if (rule.re.test(text)) deny(rule.reason, rule.id);
+  }
+  for (const rule of rules) {
+    if (rule.action !== 'ask') continue;
+    if (rule.re.test(text)) ask(rule.reason, rule.id);
   }
 }
 


### PR DESCRIPTION
## What

The safety-check hook denied `git commit` / `git push` with a hard `deny` (exit 2), which removed any way for the user to approve them in the moment. But the intent of these two rules is **human oversight, not a ban** — the reason string literally said "needs your approval." A hard block gives no approval path.

This routes them to the **approval prompt** (`permissionDecision: "ask"`) instead. The user is prompted and can allow or reject each commit/push — oversight preserved, but authorization actually works.

## Changes

- `hooks/lib/hook-io.js` — new `ask(reason, rule)` helper emitting the `ask` verdict.
- `hooks/safety-check.js` — the `git-commit` / `git-push` rules use `action: 'ask'`. `checkRules` runs all **deny** rules first, so a command that both commits and deletes (e.g. `git commit && rm -rf ...`) is still hard-blocked, never merely prompted.
- `hooks/__tests__/safety-check.test.js` — commit/push now assert the `ask` verdict; added a destructive-precedence test.

## Not changed

All destructive rules (`reset --hard`, `clean -f`, `rm -rf`, `DROP TABLE`, `npm publish`, …) still hard-`deny`. Only the two oversight gates become prompts.

222 hook tests green.
