### PR TITLE
fix(install): gitignore grill-summary.md and operator-state.md

### DIFF
--- a/install/__tests__/non-interactive.test.js
+++ b/install/__tests__/non-interactive.test.js
@@ -385,6 +385,8 @@ test('install.js --yes writes managed gitignore block, idempotent on re-install'
     assert.ok(content.includes('tasks/issues/'), 'tasks/issues/ must be in block');
     assert.ok(content.includes('tasks/todo.md'), 'tasks/todo.md must be in block');
     assert.ok(content.includes('_prototype/'), '_prototype/ (throwaway scratch) must be in block');
+    assert.ok(content.includes('grill-summary.md'), 'grill-summary.md (transient handoff) must be in block');
+    assert.ok(content.includes('operator-state.md'), 'operator-state.md (chief-operator state) must be in block');
 
     // Re-run: block should appear exactly once
     runInstallJs(['--yes', '--project', dir, ...LOCAL]);

--- a/install/install.js
+++ b/install/install.js
@@ -190,6 +190,11 @@ const MANAGED_GITIGNORE_ENTRIES = [
   // Throwaway prototype scratch — the /prototype skill deletes losing candidates
   // after a winner is picked, so these are never meant to be tracked.
   '_prototype/',
+  // Transient skill handoffs — overwritten each session, not permanent records.
+  // grill-summary.md: /grill-me and /wayfinder Decide→Define hand-off (repo root).
+  // operator-state.md: chief-operator agent state, rewritten every session.
+  'grill-summary.md',
+  'operator-state.md',
 ];
 
 function writeManagedGitignore(projectDir) {

--- a/install/lib/updater.js
+++ b/install/lib/updater.js
@@ -351,6 +351,7 @@ function handleModeCrossing(manifest, target, nonInteractive) {
     'tasks/issues/', 'tasks/todo.md', 'tasks/lessons.md', 'tasks/pr-queue.md',
     'tasks/flags-and-notes.md', 'tasks/people.md', 'tasks/admin.md',
     'tasks/tracker-config.md', 'tasks/stories/',
+    'grill-summary.md', 'operator-state.md',
   ];
   try {
     const result = spawnSync('git', ['ls-files', '--', ...managedPatterns], {


### PR DESCRIPTION
## Problem

When someone installs the harness and runs `/grill-me` or `/wayfinder`, the `grill-summary.md` it produces at the repo root was **not** gitignored. It showed up as untracked and could be committed by accident (e.g. `git add -A`).

The file *is* ignored in this dev repo — but only because it's hand-written into this repo's own `.gitignore`. That line was never part of the **managed block** the installer writes into user projects. `operator-state.md` (chief-operator state) had the exact same gap.

## Fix

- Add `grill-summary.md` and `operator-state.md` to `MANAGED_GITIGNORE_ENTRIES` — installs/updates now ignore them automatically.
- Add both to the updater's committed-file warning list, so anyone who already committed one gets told how to untrack it.
- Assert both entries in the managed-gitignore-block test.

Note: `SKILLS_CATALOG.md` was deliberately left out — it's only generated in this dev repo, never in a user install.

## Test plan

- [x] `node --test install/__tests__/*.test.js` — 79/79 pass