### PR TITLE
docs: clarify /plan runs after decomposition, not before

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The harness covers the full software development lifecycle. Both solo and enterp
 
 ```mermaid
 flowchart LR
-    P0["Decide<br/>/grill-me · /wayfinder · /grill-with-docs<br/>/decision-brief · /plan ●"]
+    P0["Decide<br/>/grill-me · /wayfinder · /grill-with-docs<br/>/decision-brief"]
     P1["Define<br/>/research · /prototype<br/>/prd · /prd-critique<br/>/architect · /architect-critique<br/>/design-artifacts · /to-issues · /to-todoist<br/>/sprint-plan ◆"]
     P2["Build<br/>/implement ● · /story ◆<br/>/run-tasks ◆<br/>/evaluate · /debug"]
     P3["Ship<br/>/babysit-pr ◆<br/>/local-test · /deploy"]
@@ -84,20 +84,23 @@ flowchart LR
 
 > ● = solo only &nbsp;&nbsp; ◆ = enterprise only &nbsp;&nbsp; unmarked = both
 
-> **Charting a big effort (`/wayfinder`) — grill-me on steroids.** When a direction is too big to settle in one `/grill-me` sitting — many open decisions, not one — start with **`/wayfinder`**. It charts a **map** on your tracker (one map item + child **decision tickets**: research / prototype / grilling / task) and resolves **one ticket per session** until every decision is made, ending in a **spec** (the destination artifact). It *plans, it never builds*. From there rejoin the normal flow: **`/architect`** formalizes the spec → **`/to-issues`** / **`/to-todoist`** creates the build tasks → **`/implement`** / **`/story`** builds them.
+> **`/plan` ● is not a linear stage.** It reads your *existing* tracker backlog and prioritizes it — so it runs *after* `/to-issues` / `/to-todoist` have created tasks, never before. Think of it as the recurring "what's next?" step at the top of each cycle, feeding straight into `/implement`.
+
+> **Charting a big effort (`/wayfinder`) — grill-me on steroids.** When a direction is too big to settle in one `/grill-me` sitting — many open decisions, not one — start with **`/wayfinder`**. It charts a **map** on your tracker (one map item + child **decision tickets**: research / prototype / grilling / task) and resolves **one ticket per session** until every decision is made, ending in a **spec** (the destination artifact). It *plans, it never builds*. From there rejoin the normal flow: **`/architect`** formalizes the spec → **`/to-issues`** / **`/to-todoist`** creates the build tasks → **`/implement`** / **`/story`** builds them. (Already sitting on a backlog? **`/plan`** prioritizes your existing issues and picks the next one to **`/implement`** — it reads tasks that already exist, so it comes *after* decomposition, never before.)
 
 #### Solo developer path
 
 ```mermaid
 flowchart LR
-    D["Decide<br/>/plan · /grill-me<br/>/wayfinder"]
+    D["Decide<br/>/grill-me<br/>/wayfinder"]
     Def["Define<br/>/prd · /architect<br/>/research"]
     B["Build<br/>/implement #42<br/>/evaluate · /debug"]
     S["Ship<br/>/local-test"]
     L["Learn<br/>/zoom-out<br/>/improve-harness"]
 
     D --> Def --> B --> S --> L
-    L -.->|"next issue"| D
+    L -.->|"new idea"| D
+    L -.->|"next from backlog · /plan"| B
 ```
 
 #### Enterprise team path

--- a/skills/wayfinder/SKILL.md
+++ b/skills/wayfinder/SKILL.md
@@ -114,6 +114,8 @@ Then the normal flow consumes it with **zero glue**:
 
 `/wayfinder` → **`grill-summary.md`** → `/architect` (auto-detects it → `ARCHITECTURE.md`) → `/to-issues` or `/to-todoist` (build tasks) → `/implement` or `/story` (build).
 
+`/plan` is not a step in this chain — it reads the tracker tasks that `/to-issues` / `/to-todoist` create and prioritizes them, so it runs *after* decomposition (never before) whenever you have a backlog to pick from.
+
 **When the destination is a locked decision or a change made in place** (not a build), there is no grill-summary hand-off — the map plus its `Decided:` comments *are* the artifact; point at them and stop.
 
 Writing the grill-summary is the map's one planning deliverable — it records decisions for the next phase; it does not build (consistent with "plan, don't do").


### PR DESCRIPTION
## Summary

Fixes an internal inconsistency in how the docs describe where `/plan` sits in the pipeline.

`/plan` **reads** existing tracker tasks and prioritizes them — so it must run *after* `/to-issues` / `/to-todoist` **create** those tasks, never before. But the README's SDLC and solo-path diagrams placed `/plan` in the upstream **Decide** phase, ahead of the **Define** phase that holds `/to-issues` / `/to-todoist` — the opposite of its actual read-from-tracker behavior. The canonical pipeline prose also omitted `/plan` entirely, so its position was never stated authoritatively anywhere.

## Changes

- **SDLC "at a glance" diagram** — removed `/plan` from the Decide box (it's not a linear stage).
- **Solo-path diagram** — `/plan` now sits on the backlog return-loop (`next from backlog · /plan → Build`), with a separate `new idea → Decide` arrow. This shows the truth: `/plan` skips decomposition and feeds straight to `/implement`.
- **Clarifying note** under the diagram — `/plan` is the recurring "what's next?" step that reads an already-populated backlog.
- **Canonical pipeline prose** (README + `skills/wayfinder/SKILL.md`) — now states `/plan` prioritizes existing tasks and runs after decomposition, never before.

## Why

`/plan` is a recurring backlog-prioritization loop, not a step in the new-feature decomposition chain. The docs now express that consistently everywhere.

## Test plan

- [ ] Docs-only change — render the README on GitHub and confirm both mermaid diagrams parse and read correctly.