### PR TITLE
chore: align package.json to 3.1.0 + tag v3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-harness",
-  "version": "2.0.0",
+  "version": "3.1.0",
   "private": true,
   "description": "Dev-only manifest for tests and lint. Not copied by the installer; runtime stays zero-dep.",
   "scripts": {


### PR DESCRIPTION
## What

Aligns all three version sources so they agree at **3.1.0**.

| Source | Before | After |
|---|---|---|
| `VERSION` | 3.1.0 | 3.1.0 (unchanged) |
| `package.json` | 2.0.0 | **3.1.0** |
| git tag | v2.0.0 (latest) | **v3.1.0** |

## Why

`VERSION` had advanced to 3.1.0 across the 3.x work, but `package.json` and the git tags were never bumped alongside it — leaving pinned-channel users effectively stuck at v2.0.0 and the sources contradicting each other.

## Notes

- Tag `v3.1.0` is pushed pointing at this branch's commit; it stays valid under a merge-commit merge (this repo's strategy).
- Follow-up tracked in Todoist ("Tighten version-bump loop"): add `RELEASING.md` + a hook warning when `VERSION` and `package.json` disagree on a bump.