### PR TITLE
feat(hooks): extend inventory-check with docs-drift warnings + release gate

### DIFF
--- a/hooks/__tests__/inventory-check.test.js
+++ b/hooks/__tests__/inventory-check.test.js
@@ -75,7 +75,7 @@ test('inventory-check_NewAgentMissingFromReadmeTable_Denies', () => {
   fs.rmSync(dir, { recursive: true, force: true });
 });
 
-test('inventory-check_NewAgentMissingFromChangelog_Denies', () => {
+test('inventory-check_NewAgentMissingFromChangelog_Warns', () => {
   const dir = makeRepo({
     'README.md': '2 agents\n| `foo` | opus |\n| `bar` | opus |',
     'CHANGELOG.md': '## [Unreleased]\nnothing here',
@@ -83,8 +83,8 @@ test('inventory-check_NewAgentMissingFromChangelog_Denies', () => {
   });
   stageNewFile(dir, 'agents/bar.md', '---\nname: bar\n---');
   const r = runHook({ command: 'git commit -m "add bar"' }, dir);
-  assert.strictEqual(r.exitCode, 2);
-  assert.match(r.json.reason, /CHANGELOG\.md.*missing entry for `bar`/);
+  assert.strictEqual(r.exitCode, 0);
+  assert.match(r.json.hookSpecificOutput.additionalContext, /no entry for new agent `bar`/);
   fs.rmSync(dir, { recursive: true, force: true });
 });
 
@@ -113,16 +113,85 @@ test('inventory-check_AllUpdated_Allows', () => {
   fs.rmSync(dir, { recursive: true, force: true });
 });
 
-test('inventory-check_NewSkillMissingFromChangelog_Denies', () => {
+test('inventory-check_NewSkillMissingFromChangelog_Warns', () => {
   const dir = makeRepo({
-    'README.md': '1 skills',
+    'README.md': '2 skills',
     'CHANGELOG.md': '## [Unreleased]\nnothing',
     'skills/foo/SKILL.md': '---\nname: foo\n---',
   });
   stageNewFile(dir, 'skills/bar/SKILL.md', '---\nname: bar\n---');
   const r = runHook({ command: 'git commit -m "add bar skill"' }, dir);
+  assert.strictEqual(r.exitCode, 0);
+  assert.match(r.json.hookSpecificOutput.additionalContext, /no entry for new skill `bar`/);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('inventory-check_VersionBumpEmptyUnreleased_Denies', () => {
+  const dir = makeRepo({
+    'README.md': '1 skills',
+    'CHANGELOG.md': '## [Unreleased]\n\n## [3.0.0]\n- old stuff',
+    'VERSION': '3.0.0',
+    'skills/foo/SKILL.md': '---\nname: foo\n---',
+  });
+  fs.writeFileSync(path.join(dir, 'VERSION'), '3.1.0');
+  execFileSync('git', ['add', 'VERSION'], { cwd: dir });
+  const r = runHook({ command: 'git commit -m "bump version"' }, dir);
   assert.strictEqual(r.exitCode, 2);
-  assert.match(r.json.reason, /CHANGELOG.*missing entry for skill `bar`/);
+  assert.match(r.json.reason, /\[Unreleased\] has no entries/);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('inventory-check_VersionBumpWithUnreleasedEntries_Allows', () => {
+  const dir = makeRepo({
+    'README.md': '1 skills',
+    'CHANGELOG.md': '## [Unreleased]\n\n### Added\n\n- new thing\n\n## [3.0.0]\n- old',
+    'VERSION': '3.0.0',
+    'skills/foo/SKILL.md': '---\nname: foo\n---',
+  });
+  fs.writeFileSync(path.join(dir, 'VERSION'), '3.1.0');
+  execFileSync('git', ['add', 'VERSION'], { cwd: dir });
+  const r = runHook({ command: 'git commit -m "bump version"' }, dir);
+  assert.strictEqual(r.exitCode, 0);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('inventory-check_NewHook_Warns', () => {
+  const dir = makeRepo({
+    'README.md': '1 skills',
+    'CHANGELOG.md': '## [Unreleased]\n\n- something',
+  });
+  stageNewFile(dir, 'hooks/new-thing.js', '// hook');
+  const r = runHook({ command: 'git commit -m "add hook"' }, dir);
+  assert.strictEqual(r.exitCode, 0);
+  assert.match(r.json.hookSpecificOutput.additionalContext, /New hook `new-thing\.js`/);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('inventory-check_RemovedSkill_Warns', () => {
+  const dir = makeRepo({
+    'README.md': '1 skills',
+    'CHANGELOG.md': '## [Unreleased]\n\n- x',
+    'skills/foo/SKILL.md': '---\nname: foo\n---',
+    'skills/bar/SKILL.md': '---\nname: bar\n---',
+  });
+  execFileSync('git', ['rm', 'skills/bar/SKILL.md'], { cwd: dir });
+  const r = runHook({ command: 'git commit -m "remove bar"' }, dir);
+  assert.strictEqual(r.exitCode, 0);
+  assert.match(r.json.hookSpecificOutput.additionalContext, /Skill `bar` removed/);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('inventory-check_LandingPageCountMismatch_Warns', () => {
+  const dir = makeRepo({
+    'README.md': '2 skills',
+    'CHANGELOG.md': '## [Unreleased]\n\n- bar added',
+    'docs/index.html': '<div class="num">1</div><div class="what">Skills</div>',
+    'skills/foo/SKILL.md': '---\nname: foo\n---',
+  });
+  stageNewFile(dir, 'skills/bar/SKILL.md', '---\nname: bar\n---');
+  const r = runHook({ command: 'git commit -m "add bar"' }, dir);
+  assert.strictEqual(r.exitCode, 0);
+  assert.match(r.json.hookSpecificOutput.additionalContext, /docs\/index\.html shows 1 Skills but skills\/ has 2/);
   fs.rmSync(dir, { recursive: true, force: true });
 });
 

--- a/hooks/inventory-check.js
+++ b/hooks/inventory-check.js
@@ -1,13 +1,33 @@
 #!/usr/bin/env node
 // @ts-check
-// PreToolUse hook — validates README/CHANGELOG consistency when committing
-// new agents, skills, or hooks. Only fires on `git commit` commands.
-// Fail-open: if staged files can't be determined, allows the commit.
+// PreToolUse hook — keeps the repo's advertised inventory honest with its docs.
+// Fires only on `git commit` commands. Fail-open: if staged files can't be
+// determined, allows the commit.
+//
+// Two severities:
+//
+//  HARD BLOCK (deny — objective, cheap to fix):
+//   1. A newly-added skill/agent missing its README table row.
+//   2. README "N skills" / "N agents" count out of sync with the tree.
+//   3. VERSION being changed while CHANGELOG [Unreleased] has no entries —
+//      the release gate. This is the answer to "when do I update the
+//      changelog?": not every PR, but it MUST be filled before a version bump.
+//
+//  WARN (soft reminder, does not block — subjective / judgment calls):
+//   - CHANGELOG [Unreleased] has no line for a new skill/agent.
+//   - A hook or rule was added or removed (consider a CHANGELOG entry).
+//   - A skill/agent was removed (update README, CHANGELOG, landing page).
+//   - docs/index.html skill/agent count drifted from the tree.
+//
+// Rationale for the split: countable README facts drift silently and are
+// trivial to correct, so they stay hard blocks. Landing-page copy and
+// changelog prose are judgment calls — a warning respects the author without
+// training them to resent a gate that false-positives.
 
 const { execFileSync } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
-const { readStdinJson, deny, ok, runHook } = require('./lib/hook-io');
+const { readStdinJson, deny, injectContext, ok, runHook } = require('./lib/hook-io');
 
 function git(args) {
   try { return execFileSync('git', args, { encoding: 'utf8' }).trim(); }
@@ -16,6 +36,44 @@ function git(args) {
 
 function repoRoot() {
   return git(['rev-parse', '--show-toplevel']) || process.cwd();
+}
+
+function splitLines(s) {
+  return s ? s.split('\n').filter(Boolean) : [];
+}
+
+// ── inventory classifiers (repo-relative POSIX paths) ────────────────────
+const isSkillFile = (f) => /^skills\/[^/]+\/SKILL\.md$/.test(f);
+const isAgentFile = (f) => /^agents\/[^/]+\.md$/.test(f);
+const isHookFile = (f) => /^hooks\/[^/]+\.js$/.test(f); // top-level only; excludes lib/ and __tests__/
+const isRuleFile = (f) => /^rules\/[^/]+\.md$/.test(f);
+
+function countAgents(root) {
+  const dir = path.join(root, 'agents');
+  if (!fs.existsSync(dir)) return 0;
+  return fs.readdirSync(dir).filter((f) => f.endsWith('.md')).length;
+}
+
+function countSkills(root) {
+  const dir = path.join(root, 'skills');
+  if (!fs.existsSync(dir)) return 0;
+  return fs.readdirSync(dir).filter((d) =>
+    fs.existsSync(path.join(dir, d, 'SKILL.md'))
+  ).length;
+}
+
+// Reads a plate count from the landing page: <div class="num">34</div><div class="what">Skills</div>
+function landingCount(html, word) {
+  const re = new RegExp('class="num">\\s*(\\d+)\\s*</div>\\s*<div class="what">\\s*' + word, 'i');
+  const m = html.match(re);
+  return m ? parseInt(m[1], 10) : null;
+}
+
+// True when the [Unreleased] section has no bullet entries (release gate).
+function unreleasedIsEmpty(changelog) {
+  const m = changelog.match(/##\s*\[Unreleased\][^\n]*\n([\s\S]*?)(?=\n##\s|\n---|$)/i);
+  if (!m) return true; // no [Unreleased] section at all → treat as needing entries
+  return !/^\s*[-*]\s+\S/m.test(m[1]);
 }
 
 runHook('inventory-check', async () => {
@@ -30,76 +88,115 @@ runHook('inventory-check', async () => {
 
   if (!fs.existsSync(readmePath) || !fs.existsSync(changelogPath)) return ok();
 
-  const staged = git(['diff', '--cached', '--name-only', '--diff-filter=A']);
-  if (!staged) return ok();
+  const stagedAll = splitLines(git(['diff', '--cached', '--name-only']));
+  const stagedAdded = splitLines(git(['diff', '--cached', '--name-only', '--diff-filter=A']));
+  const stagedDeleted = splitLines(git(['diff', '--cached', '--name-only', '--diff-filter=D']));
 
-  const stagedFiles = staged.split('\n').filter(Boolean);
-  const newAgents = stagedFiles.filter(f => f.startsWith('agents/') && f.endsWith('.md'));
-  const newSkills = stagedFiles.filter(f => f.match(/^skills\/[^/]+\/SKILL\.md$/));
+  const newAgents = stagedAdded.filter(isAgentFile);
+  const newSkills = stagedAdded.filter(isSkillFile);
+  const newHooks = stagedAdded.filter(isHookFile);
+  const newRules = stagedAdded.filter(isRuleFile);
+  const removedAgents = stagedDeleted.filter(isAgentFile);
+  const removedSkills = stagedDeleted.filter(isSkillFile);
+  const removedHooks = stagedDeleted.filter(isHookFile);
+  const removedRules = stagedDeleted.filter(isRuleFile);
 
-  if (!newAgents.length && !newSkills.length) return ok();
+  const versionBumped = stagedAll.includes('VERSION');
+  const inventoryTouched =
+    newAgents.length || newSkills.length || newHooks.length || newRules.length ||
+    removedAgents.length || removedSkills.length || removedHooks.length || removedRules.length;
+
+  if (!inventoryTouched && !versionBumped) return ok();
 
   const readme = fs.readFileSync(readmePath, 'utf8');
   const changelog = fs.readFileSync(changelogPath, 'utf8');
-  const problems = [];
+  const landingPath = path.join(root, 'docs', 'index.html');
+  const landing = fs.existsSync(landingPath) ? fs.readFileSync(landingPath, 'utf8') : null;
 
+  const hardProblems = [];
+  const warnings = [];
+
+  // ── Agents: HARD table row + count, WARN changelog entry ────────────────
   for (const agentFile of newAgents) {
     const name = path.basename(agentFile, '.md');
-
     const tableRow = new RegExp('\\|\\s*`' + escapeRegex(name) + '`\\s*\\|');
     if (!tableRow.test(readme)) {
-      problems.push(`README.md agent table missing row for \`${name}\``);
+      hardProblems.push(`README.md agent table missing row for \`${name}\``);
     }
-
     if (!changelog.includes(name)) {
-      problems.push(`CHANGELOG.md [Unreleased] missing entry for \`${name}\``);
+      warnings.push(`CHANGELOG.md [Unreleased] has no entry for new agent \`${name}\``);
     }
   }
-
-  if (newAgents.length) {
-    const agentDir = path.join(root, 'agents');
-    if (fs.existsSync(agentDir)) {
-      const actualCount = fs.readdirSync(agentDir).filter(f => f.endsWith('.md')).length;
-      const countMatch = readme.match(/(\d+)\s+agents/);
-      if (countMatch) {
-        const readmeCount = parseInt(countMatch[1], 10);
-        if (readmeCount !== actualCount) {
-          problems.push(`README.md says ${readmeCount} agents but agents/ has ${actualCount} .md files`);
-        }
+  if (newAgents.length || removedAgents.length) {
+    const actual = countAgents(root);
+    const m = readme.match(/(\d+)\s+agents/);
+    if (m && parseInt(m[1], 10) !== actual) {
+      hardProblems.push(`README.md says ${m[1]} agents but agents/ has ${actual} .md files`);
+    }
+    if (landing) {
+      const lc = landingCount(landing, 'Agents');
+      if (lc !== null && lc !== actual) {
+        warnings.push(`docs/index.html shows ${lc} Agents but agents/ has ${actual}`);
       }
     }
   }
 
+  // ── Skills: HARD count, WARN changelog entry ────────────────────────────
   for (const skillFile of newSkills) {
     const skillName = skillFile.split('/')[1];
-
     if (!changelog.includes(skillName)) {
-      problems.push(`CHANGELOG.md [Unreleased] missing entry for skill \`${skillName}\``);
+      warnings.push(`CHANGELOG.md [Unreleased] has no entry for new skill \`${skillName}\``);
     }
   }
-
-  if (newSkills.length) {
-    const skillsDir = path.join(root, 'skills');
-    if (fs.existsSync(skillsDir)) {
-      const actualCount = fs.readdirSync(skillsDir).filter(d => {
-        const skillPath = path.join(skillsDir, d, 'SKILL.md');
-        return fs.existsSync(skillPath);
-      }).length;
-      const countMatch = readme.match(/(\d+)\s+skills/);
-      if (countMatch) {
-        const readmeCount = parseInt(countMatch[1], 10);
-        if (readmeCount !== actualCount) {
-          problems.push(`README.md says ${readmeCount} skills but skills/ has ${actualCount}`);
-        }
+  if (newSkills.length || removedSkills.length) {
+    const actual = countSkills(root);
+    const m = readme.match(/(\d+)\s+skills/);
+    if (m && parseInt(m[1], 10) !== actual) {
+      hardProblems.push(`README.md says ${m[1]} skills but skills/ has ${actual}`);
+    }
+    if (landing) {
+      const lc = landingCount(landing, 'Skills');
+      if (lc !== null && lc !== actual) {
+        warnings.push(`docs/index.html shows ${lc} Skills but skills/ has ${actual}`);
       }
     }
   }
 
-  if (problems.length) {
-    deny(
-      'Inventory check failed — update these before committing:\n' +
-      problems.map(p => '  - ' + p).join('\n'),
-      'inventory-check'
+  // ── WARN: removed skills/agents ─────────────────────────────────────────
+  for (const f of removedSkills) {
+    warnings.push(`Skill \`${f.split('/')[1]}\` removed — update README, CHANGELOG, and docs/index.html`);
+  }
+  for (const f of removedAgents) {
+    warnings.push(`Agent \`${path.basename(f, '.md')}\` removed — update README, CHANGELOG, and docs/index.html`);
+  }
+
+  // ── WARN: new/removed hooks & rules ─────────────────────────────────────
+  for (const f of newHooks) warnings.push(`New hook \`${path.basename(f)}\` — consider a CHANGELOG [Unreleased] entry`);
+  for (const f of removedHooks) warnings.push(`Hook \`${path.basename(f)}\` removed — consider a CHANGELOG [Unreleased] entry`);
+  for (const f of newRules) warnings.push(`New rule \`${path.basename(f)}\` — consider a CHANGELOG [Unreleased] entry`);
+  for (const f of removedRules) warnings.push(`Rule \`${path.basename(f)}\` removed — consider a CHANGELOG [Unreleased] entry`);
+
+  // ── HARD: release gate — VERSION bumped but [Unreleased] empty ──────────
+  if (versionBumped && unreleasedIsEmpty(changelog)) {
+    hardProblems.push('VERSION is being changed but CHANGELOG [Unreleased] has no entries — fill it before cutting a release');
+  }
+
+  if (hardProblems.length) {
+    let reason =
+      'Inventory check failed — fix before committing:\n' +
+      hardProblems.map((p) => '  - ' + p).join('\n');
+    if (warnings.length) {
+      reason +=
+        '\n\nAlso worth updating (not blocking):\n' +
+        warnings.map((w) => '  - ' + w).join('\n');
+    }
+    deny(reason, 'inventory-check');
+  }
+
+  if (warnings.length) {
+    injectContext(
+      'PreToolUse',
+      'Docs reminder (not blocking) — ' + warnings.join('; ') + '.'
     );
   }
 


### PR DESCRIPTION
## What

Broadens the existing commit-time `inventory-check` hook (fires on `git commit`, fail-open) so docs stay honest with the repo's advertised inventory.

### Hard block (objective, cheap to fix)
- **Kept:** a new skill/agent missing its README table row; README "N skills/agents" count out of sync with the tree.
- **New — release gate:** bumping `VERSION` while CHANGELOG `[Unreleased]` has no entries. This encodes *when* to update the changelog: not every PR, but it must be filled before a version bump.

### Warn, non-blocking (judgment calls)
- **Downgraded from block:** missing `[Unreleased]` entry for a new skill/agent.
- **New coverage:** a hook or rule added/removed; a skill/agent removed; `docs/index.html` (landing page) skill/agent count drifted from the tree.

## Why

Docs drift silently — the landing-page counts had already fallen out of sync. Countable README facts are trivial to fix, so they stay hard blocks; prose/landing-page/changelog nudges are warnings, to avoid a gate that false-positives and trains people to resent it.

## Tests

`hooks/__tests__/inventory-check.test.js` — **13 tests, all passing** (2 rewritten for the warn downgrade, 5 new for the release gate, hook/rule coverage, removals, and landing-page drift).