### PR TITLE
chore(ci): shellcheck gate, Node 20/22 matrix, and Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  # Dev dependencies in package.json (eslint, typescript, c8, @types/node)
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+
+  # The GitHub Actions used in .github/workflows/*.yml (checkout, setup-node)
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,15 +11,20 @@ permissions:
 
 jobs:
   test:
-    name: Test & Lint
+    name: Test & Lint (Node ${{ matrix.node }})
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [20, 22]
 
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ matrix.node }}
 
       - run: npm install
 
@@ -31,3 +36,15 @@ jobs:
 
       - name: Test with coverage
         run: npm run test:coverage
+
+  shellcheck:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # shellcheck is preinstalled on ubuntu-latest runners.
+      # Gate at error severity only; warnings/info are not enforced yet.
+      - name: ShellCheck
+        run: git ls-files -z '*.sh' | xargs -0 -r shellcheck --severity=error

--- a/trackers/ado/remove-label.sh
+++ b/trackers/ado/remove-label.sh
@@ -40,7 +40,7 @@ if [ -z "$EXISTING_TAGS" ]; then
 fi
 
 # Remove the tag (case-insensitive), then clean up separators
-NEW_TAGS=$(echo "$EXISTING_TAGS" | sed "s/[;,] *$TAG//gi" | sed "s/$TAG[;,] *//gi" | sed "s/$TAG//gi" | sed 's/^[; ]*//;s/[; ]*$//')
+NEW_TAGS=$(echo "$EXISTING_TAGS" | sed "s/[;,] *${TAG}//gi" | sed "s/${TAG}[;,] *//gi" | sed "s/${TAG}//gi" | sed 's/^[; ]*//;s/[; ]*$//')
 
 with_retry az boards work-item update \
   --id "$WORK_ITEM_ID" \


### PR DESCRIPTION
## Summary

Hardens the CI pipeline with three low-effort, high-value additions. CI was previously CI-only (lint + typecheck + test on Node 20) and never checked the Bash scripts that make up most of the runtime.

- **ShellCheck gate** — new parallel job runs `shellcheck` over all tracked `*.sh` files (95 scripts), gated at **error severity** so only genuine bugs fail the build. Warnings (10) and info (~165) are surfaced-but-not-enforced; severity can be ratcheted up later.
- **Node version matrix** — the Test & Lint job now runs on **Node 20 and 22** (`fail-fast: false`), proving the `engines: node >=20` range actually holds.
- **Dependabot** — new `.github/dependabot.yml` watches npm dev-deps (eslint, typescript, c8, @types/node) and the GitHub Actions themselves; weekly, max 5 open PRs each.

## Bug fixed to make the gate green

`trackers/ado/remove-label.sh:43` — `$TAG[;,]` inside a sed expression was parsed by ShellCheck as an array index (SC1087). Braced the three `$TAG` expansions (`${TAG}`) — identical behavior in sed, unambiguous to the linter.

## Test plan

- [x] `git ls-files -z '*.sh' | xargs -0 -r shellcheck --severity=error` passes locally (0 findings)
- [x] Both YAML files parse
- [x] CI green on Node 20 and Node 22
- [x] ShellCheck job green on the runner