### PR TITLE
fix: auto-read default section from config in Todoist create-issue

### DIFF
--- a/trackers/todoist/create-issue.sh
+++ b/trackers/todoist/create-issue.sh
@@ -40,6 +40,14 @@ if [ -z "$PROJECT" ]; then
   fi
 fi
 
+# Auto-read default section from config when not passed as argument.
+# Mirrors the project auto-read above and the same key get-sprint-issues.sh reads
+# for listing. Blank config = no-op: the task lands at the project root as before.
+if [ -z "$SECTION" ] && [ -f "tasks/tracker-config.md" ]; then
+  _sec=$(grep -i "todoist_default_section[[:space:]]*=" tasks/tracker-config.md | sed 's/.*=[[:space:]]*//; s/[[:space:]]*$//' | tr -d '\r')
+  [ -n "$_sec" ] && SECTION="$_sec"
+fi
+
 CREATE_ARGS=(task add "$TITLE")
 
 if [ -n "$BODY" ]; then


### PR DESCRIPTION
## Summary
- `create-issue.sh` only placed tasks into a Todoist section when one was passed explicitly as the fourth argument, so harness-created tasks landed at the project root even when `todoist_default_section` was configured.
- Mirror the existing project auto-read: when no section argument is given, fall back to `todoist_default_section` from `tasks/tracker-config.md`, using the identical parsing already used by `list-issues.sh` and `get-sprint-issues.sh`.
- Blank config remains a no-op (task lands at project root as before), and an explicit fourth argument still wins.

## Test plan
- [x] Verified parsing matches `list-issues.sh` / `get-sprint-issues.sh` line-for-line
- [x] Smoke-tested extraction against this repo's real `tracker-config.md` (extracts `claude-code-harness`)
- [x] `bash -n` syntax check passes
- [x] Confirmed both templates ship the key blank, so fresh installs are unaffected