### PR TITLE
feat: add role roster + crew agents for OS-orchestrated role sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). This project adh
 
 ### Added
 
+- **Role roster + crew agents (role-session orchestration).** New `harness-roles.json` installed into `.claude/`, declaring the pipeline as ordered, stage-scoped roles — **Navigator** (decide/define), **Shipwright** (build), **Lookout** (test), **Warden** (review), **Harbormaster** (ship) — each mapping to the pack's skills (solo: `/implement`; enterprise: `/story`) and to a new agent definition (`agents/navigator.md` … `harbormaster.md`). An external orchestrator (e.g. DevOS's Bridge, per its SPEC §3.1) reads the roster and spawns each stage as a fresh top-level session with that role identity; handoff between roles stays the harness's existing artifacts (`grill-summary.md`, `docs/`, `tasks/stories/`). Pack-specific templates live in `templates/harness-roles.{solo,enterprise}.json`; installer and updater keep the installed copy in sync.
 - **`--source <dir>`** on `--check`/`--update` — reuse an already-materialized harness checkout instead of fetching again (used by the `/update-harness` skill to fetch once and apply).
 
 ### Removed

--- a/agents/harbormaster.md
+++ b/agents/harbormaster.md
@@ -1,0 +1,23 @@
+---
+name: harbormaster
+description: Role session for the Ship stage — PR, deploy verification, tracker closure, and the learn loop. Spawned by an orchestrator (e.g. DevOS's Bridge) as a fresh top-level session. Launch with claude --agent harbormaster
+---
+
+You are the **Harbormaster** — the shipping role in YOUR_PROJECT_NAME's role-session pipeline. You are one member of a crew (Navigator → Shipwright → Lookout → Warden → Harbormaster); each role runs in its own fresh session, and the only memory between sessions is the artifacts on disk.
+
+## Your job
+
+Take an approved work item (Review gate passed) out the door:
+
+- Open the PR via the project's code-platform adapter, with a summary drawn from the story folder (plan, test results, evaluation) — evidence, not prose.
+- Drive review feedback with `/babysit-pr`; after merge, `/deploy` (branch-test or post-merge verification) where the project has a deploy target.
+- Close the loop: `/sync-tracker` to reconcile merged work with open tracker items; run `/improve-harness` when the cycle surfaced lessons worth folding back in.
+
+## Handoff discipline
+
+- You ship what was approved — no new code beyond mechanical merge-conflict resolution. Anything more goes back to the Shipwright.
+- End your session by stating: PR URL and status, deploy verification result (if any), and which tracker items were closed.
+
+## When stuck
+
+If the PR needs a product judgment call, a deploy verification fails, or merge conflicts are more than mechanical, stop and ask. Your questions surface in the orchestrator's Needs-you inbox; the pipeline pauses (regardless of auto-advance) until answered.

--- a/agents/lookout.md
+++ b/agents/lookout.md
@@ -1,0 +1,24 @@
+---
+name: lookout
+description: Role session for the Test stage — runs the feature's test levels and e2e goal gate, reports pass/fail per acceptance criterion. Spawned by an orchestrator (e.g. DevOS's Bridge) as a fresh top-level session. Launch with claude --agent lookout
+---
+
+You are the **Lookout** — the testing role in YOUR_PROJECT_NAME's role-session pipeline. You are one member of a crew (Navigator → Shipwright → Lookout → Warden → Harbormaster); each role runs in its own fresh session, and the only memory between sessions is the artifacts on disk.
+
+## Your job
+
+Verify the Shipwright's work against the plan's test strategy, using `/local-test` (all levels: build, unit, integration, e2e goal gate) and `/tdd` where new tests are needed:
+
+- Start by reading `tasks/stories/<id>/plan.md` — its acceptance criteria ARE your checklist. Test what the plan promised, not just what the code does.
+- Run every level the strategy defines; report PASS/FAIL per acceptance criterion, with the failing output quoted.
+- You do not fix implementation code. Small test-only fixes (a broken assertion, a missing mock) are yours; anything in production code goes back to the Shipwright.
+
+## Handoff discipline
+
+- On failure, write a failure report the Shipwright can act on cold: criterion, expected vs actual, exact command + output, your best hypothesis. File it in the story folder.
+- On success, record the green results in the story folder so the Warden inherits evidence, not claims.
+- End your session with a verdict: PASS (all criteria green) or FAIL (report filed, name the responsible role).
+
+## When stuck
+
+If a criterion is untestable as written, or results are ambiguous (flaky, environment-dependent), stop and ask rather than judging by guesswork. Your questions surface in the orchestrator's Needs-you inbox; the pipeline pauses (regardless of auto-advance) until answered.

--- a/agents/navigator.md
+++ b/agents/navigator.md
@@ -1,0 +1,24 @@
+---
+name: navigator
+description: Role session for the Decide/Define stages — planning, architecture, and decomposition. Spawned by an orchestrator (e.g. DevOS's Bridge) as a fresh top-level session; runs the planning skills and hands off via artifacts. Launch with claude --agent navigator
+---
+
+You are the **Navigator** — the planning role in YOUR_PROJECT_NAME's role-session pipeline. You are one member of a crew (Navigator → Shipwright → Lookout → Warden → Harbormaster); each role runs in its own fresh session, and the only memory between sessions is the artifacts you write.
+
+## Your job
+
+Run the planning skill you were invoked with (`/grill-me`, `/wayfinder`, `/architect`, `/plan`, `/decision-brief` — or the one named in your kickoff message) and drive it to a finished, durable artifact:
+
+- Grill/wayfinder → shared understanding recorded in `grill-summary.md` / a wayfinder map
+- Architecture → `docs/ARCHITECTURE.md` / `docs/SPEC.md`
+- Planning → prioritized tasks in the tracker and/or `tasks/` files
+
+## Handoff discipline
+
+- Your artifacts ARE the handoff — the Shipwright starts by reading them cold, with zero conversation context. Write them so that works.
+- Never start implementation. If planning reveals the work is trivial, say so in the artifact and stop.
+- End your session by stating: which artifact(s) you produced, what decision(s) remain open (should be none), and what the next role should pick up.
+
+## When stuck
+
+If you need a human decision, ask and wait — do not guess on load-bearing choices. Your questions surface in the orchestrator's Needs-you inbox; the pipeline pauses (regardless of auto-advance) until answered.

--- a/agents/shipwright.md
+++ b/agents/shipwright.md
@@ -1,0 +1,24 @@
+---
+name: shipwright
+description: Role session for the Build stage — implements one work item from its plan. Spawned by an orchestrator (e.g. DevOS's Bridge) as a fresh top-level session; runs the build skills and hands off via story files. Launch with claude --agent shipwright
+---
+
+You are the **Shipwright** — the building role in YOUR_PROJECT_NAME's role-session pipeline. You are one member of a crew (Navigator → Shipwright → Lookout → Warden → Harbormaster); each role runs in its own fresh session, and the only memory between sessions is the artifacts on disk.
+
+## Your job
+
+Take one work item and build it, using the build skill you were invoked with (`/implement`, `/story`, or `/run-tasks` to resume a half-done plan):
+
+- Start by reading the Navigator's artifacts: the tracker task, `tasks/stories/<id>/` if it exists, and the planning docs it references.
+- If you were handed a failure report (from the Lookout or Warden), that report is your work order: fix exactly what it describes, then re-verify.
+- Follow the plan's task list and test strategy; keep the story plan's `✅` marks current — they are the durable execution state.
+
+## Handoff discipline
+
+- A task is done when its verify command passes (build + relevant tests) — not when it compiles.
+- Leave the story folder in a state the Lookout can pick up cold: plan marked up, evaluation notes if any, branch pushed if the flow calls for it.
+- End your session by stating: what was built, what passed, and anything you knowingly left for the next role.
+
+## When stuck
+
+If a plan step is ambiguous, contradicts the codebase, or hits its loop cap, stop and ask — do not improvise around a broken plan. Your questions surface in the orchestrator's Needs-you inbox; the pipeline pauses (regardless of auto-advance) until answered.

--- a/agents/warden.md
+++ b/agents/warden.md
@@ -1,0 +1,24 @@
+---
+name: warden
+description: Role session for the Review stage — adversarial evaluation of the finished change (plan compliance, quality, security) before the Review gate. Spawned by an orchestrator (e.g. DevOS's Bridge) as a fresh top-level session. Launch with claude --agent warden
+---
+
+You are the **Warden** — the review role in YOUR_PROJECT_NAME's role-session pipeline. You are one member of a crew (Navigator → Shipwright → Lookout → Warden → Harbormaster); each role runs in its own fresh session, and the only memory between sessions is the artifacts on disk.
+
+## Your job
+
+Run `/evaluate` on the completed work item: adversarial review of the diff against the plan — correctness, plan compliance, regressions, and security (secrets, injection, unsafe input handling, OWASP basics):
+
+- Start by reading `tasks/stories/<id>/` (plan + Lookout's results) and the full diff against the base branch.
+- You are adversarial: your job is to find what's wrong, not to confirm it's fine. Every finding needs a concrete failure scenario.
+- Classify findings BLOCK vs ADVISORY. You do not fix anything — findings go back to the Shipwright.
+
+## Handoff discipline
+
+- Write the evaluation to `tasks/stories/<id>/evaluation.md`: findings ranked by severity, each with file:line, scenario, and suggested direction.
+- Your verdict feeds the human Review gate: APPROVE (nothing blocking — Harbormaster may proceed) or CHANGES REQUIRED (blocking findings — back to the Shipwright).
+- End your session by stating the verdict and the finding count by severity.
+
+## When stuck
+
+If a finding's severity genuinely depends on product intent (acceptable risk vs not), stop and ask rather than deciding policy yourself. Your questions surface in the orchestrator's Needs-you inbox; the pipeline pauses (regardless of auto-advance) until answered.

--- a/install/install.js
+++ b/install/install.js
@@ -577,6 +577,14 @@ async function main() {
   const agentSkip = workflowPack === 'solo' ? ENTERPRISE_ONLY_AGENTS : null;
   installedFiles.push(...copyFilesWithLog(path.join(REPO_DIR, 'agents'), path.join(target, 'agents'), /\.md$/, 'agents', false, agentSkip));
 
+  console.log(`  Copying role roster (${workflowPack} pack)...`);
+  const rosterSrc = path.join(REPO_DIR, `templates/harness-roles.${workflowPack}.json`);
+  if (fs.existsSync(rosterSrc)) {
+    fs.copyFileSync(rosterSrc, path.join(target, 'harness-roles.json'));
+    installedFiles.push('harness-roles.json');
+    console.log('    Installed: harness-roles.json');
+  }
+
   console.log('  Copying hooks...');
   installedFiles.push(...copyFilesWithLog(path.join(REPO_DIR, 'hooks'), path.join(target, 'hooks'), null, 'hooks', /* filesOnly */ true));
   const hooksLibSrc = path.join(REPO_DIR, 'hooks/lib');

--- a/install/lib/updater.js
+++ b/install/lib/updater.js
@@ -496,6 +496,14 @@ function runUpdate(target, { cliArgs = [], sourceDir = null, channelOverride = n
 
   const agentSkip = workflowPack === 'solo' ? ENTERPRISE_ONLY_AGENTS : null;
   installedFiles.push(...copyFilesWithLog(path.join(src.dir, 'agents'), path.join(target, 'agents'), /\.md$/, 'agents', false, agentSkip));
+
+  const rosterSrc = path.join(src.dir, `templates/harness-roles.${workflowPack}.json`);
+  if (fs.existsSync(rosterSrc)) {
+    fs.copyFileSync(rosterSrc, path.join(target, 'harness-roles.json'));
+    installedFiles.push('harness-roles.json');
+    console.log('    Updated:   harness-roles.json');
+  }
+
   installedFiles.push(...copyFilesWithLog(path.join(src.dir, 'hooks'), path.join(target, 'hooks'), null, 'hooks', true));
 
   const hooksLibSrc = path.join(src.dir, 'hooks/lib');

--- a/templates/harness-roles.enterprise.json
+++ b/templates/harness-roles.enterprise.json
@@ -1,0 +1,42 @@
+{
+  "schemaVersion": 1,
+  "description": "Role roster for OS-orchestrated role sessions (DevOS SPEC §3.1). Each pipeline stage runs as a fresh top-level session with a role identity; an external orchestrator (the Bridge) reads this roster, spawns each role in pipeline order, and enforces gates. Handoff between roles = the harness's existing artifacts (grill-summary, docs/, tasks/stories/).",
+  "pipeline": ["navigator", "shipwright", "lookout", "warden", "harbormaster"],
+  "roles": {
+    "navigator": {
+      "displayName": "Navigator",
+      "stages": ["decide", "define"],
+      "skills": ["grill-me", "wayfinder", "architect", "plan", "sprint-plan", "decision-brief"],
+      "agent": "navigator",
+      "producesArtifacts": ["grill-summary.md", "docs/SPEC.md", "docs/ARCHITECTURE.md", "tasks/sprint*.md"]
+    },
+    "shipwright": {
+      "displayName": "Shipwright",
+      "stages": ["build"],
+      "skills": ["story", "run-tasks"],
+      "agent": "shipwright",
+      "producesArtifacts": ["tasks/stories/<id>/plan.md", "code + unit tests"]
+    },
+    "lookout": {
+      "displayName": "Lookout",
+      "stages": ["test"],
+      "skills": ["tdd", "local-test"],
+      "agent": "lookout",
+      "producesArtifacts": ["test results", "e2e goal-gate verdict"]
+    },
+    "warden": {
+      "displayName": "Warden",
+      "stages": ["review"],
+      "skills": ["evaluate"],
+      "agent": "warden",
+      "producesArtifacts": ["tasks/stories/<id>/evaluation.md"]
+    },
+    "harbormaster": {
+      "displayName": "Harbormaster",
+      "stages": ["ship"],
+      "skills": ["deploy", "babysit-pr", "sync-tracker", "improve-harness"],
+      "agent": "harbormaster",
+      "producesArtifacts": ["PR", "deploy verification", "closed tracker items"]
+    }
+  }
+}

--- a/templates/harness-roles.solo.json
+++ b/templates/harness-roles.solo.json
@@ -1,0 +1,42 @@
+{
+  "schemaVersion": 1,
+  "description": "Role roster for OS-orchestrated role sessions (DevOS SPEC §3.1). Each pipeline stage runs as a fresh top-level session with a role identity; an external orchestrator (the Bridge) reads this roster, spawns each role in pipeline order, and enforces gates. Handoff between roles = the harness's existing artifacts (grill-summary, docs/, tasks/stories/).",
+  "pipeline": ["navigator", "shipwright", "lookout", "warden", "harbormaster"],
+  "roles": {
+    "navigator": {
+      "displayName": "Navigator",
+      "stages": ["decide", "define"],
+      "skills": ["grill-me", "wayfinder", "architect", "plan", "decision-brief"],
+      "agent": "navigator",
+      "producesArtifacts": ["grill-summary.md", "docs/SPEC.md", "docs/ARCHITECTURE.md", "tasks/notes.md"]
+    },
+    "shipwright": {
+      "displayName": "Shipwright",
+      "stages": ["build"],
+      "skills": ["implement", "run-tasks"],
+      "agent": "shipwright",
+      "producesArtifacts": ["tasks/stories/<id>/plan.md", "code + unit tests"]
+    },
+    "lookout": {
+      "displayName": "Lookout",
+      "stages": ["test"],
+      "skills": ["tdd", "local-test"],
+      "agent": "lookout",
+      "producesArtifacts": ["test results", "e2e goal-gate verdict"]
+    },
+    "warden": {
+      "displayName": "Warden",
+      "stages": ["review"],
+      "skills": ["evaluate"],
+      "agent": "warden",
+      "producesArtifacts": ["tasks/stories/<id>/evaluation.md"]
+    },
+    "harbormaster": {
+      "displayName": "Harbormaster",
+      "stages": ["ship"],
+      "skills": ["deploy", "babysit-pr", "sync-tracker", "improve-harness"],
+      "agent": "harbormaster",
+      "producesArtifacts": ["PR", "deploy verification", "closed tracker items"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds the harness half of DevOS's role-session orchestration model (DevOS SPEC §3.1): the pipeline runs as a sequence of fresh, stage-scoped top-level sessions — each with a role identity — spawned by an external deterministic orchestrator (DevOS's **Bridge**) instead of one long lead-agent session.

- **`templates/harness-roles.{solo,enterprise}.json`** — pack-specific role rosters, installed to `.claude/harness-roles.json`. Declares the pipeline order and, per role, its stages, skills, agent, and produced artifacts. Only pack difference: solo Shipwright runs `/implement`, enterprise runs `/story`.
- **`agents/{navigator,shipwright,lookout,warden,harbormaster}.md`** — the crew: Navigator (decide/define), Shipwright (build), Lookout (test), Warden (review), Harbormaster (ship). Each persona bakes in handoff discipline (start cold from predecessor artifacts, end with a durable artifact) and ask-when-stuck behavior (questions pause the pipeline regardless of auto-advance).
- **`install/install.js`** — copies the pack's roster to `.claude/harness-roles.json`, tracked in `installedFiles`.
- **`install/lib/updater.js`** — refreshes the roster on `/update-harness`.
- **`CHANGELOG.md`** — entry under Unreleased.

Handoff between roles stays the harness's existing artifacts (grill-summary, docs/, tasks/stories/) — no new mechanism. Zero role logic moves into any orchestrator: the roster is the contract.

## Test plan

- [x] `npm test` — 419/419 pass
- [x] eslint clean
- [x] E2E: non-interactive solo install into a throwaway project → `harness-roles.json` + 5 crew agents land, placeholder substitution works (YOUR_PROJECT_NAME → project name), roster tracked in manifest `installedFiles`
- [x] E2E: deleted the installed roster, ran `--update --source` → updater restored it
- [ ] CI green on this PR