### PR TITLE
feat(autonomous): --autonomous flag + inherited propagation to sub-skills

### DIFF
--- a/rules/autonomous-mode.md
+++ b/rules/autonomous-mode.md
@@ -1,0 +1,126 @@
+# Autonomous Mode — Inherited Convention (Harness Rule)
+
+This file is the **single source of truth** for how autonomous mode behaves across the harness. The
+`--autonomous` flag is declared on the **orchestrator skills only** (`/implement`, and — as sibling
+work — `/story`). Every sub-skill and agent an orchestrator invokes **inherits** the mode; sub-skills
+have **no `--autonomous` flag of their own** (grill decision, fork 6).
+
+**Location:** `rules/autonomous-mode.md` (installed alongside `.claude/skills/`; the `.claude/` copy
+is a symlink to this file).
+**Referenced by:** `skills/implement/SKILL.md`, `skills/run-tasks/SKILL.md`, `skills/tdd/SKILL.md`,
+`skills/debug/SKILL.md`, `skills/local-test/SKILL.md`.
+
+---
+
+## What autonomous mode is
+
+An autonomous run executes the **entire** flow with **no human STOP checkpoints**. The PR is the
+single human gate. The mode changes *only whether the flow pauses* — it changes nothing about *what
+work is done*: every phase, the goal definition, the e2e gate, local tests, and all safety machinery
+still run.
+
+---
+
+## The self-answer rule (the core of the mode)
+
+At every point where the flow would normally STOP and wait for a human:
+
+- If the decision is **reversible** AND there is a clear recommended option → **take the recommended
+  option, do not wait**, and append one line to the **decisions log** (below).
+- Otherwise → **pause and ask.** This is the only thing that stops an autonomous run mid-flight.
+
+## Pause-anyway triggers
+
+An autonomous run stops and asks the human on any of these, regardless of the self-answer rule:
+
+- **Contradiction** — the task, brief, or code conflict in a way you cannot reconcile with a
+  recommendation.
+- **Irreversible action** — anything destructive or hard to undo (deleting data, force-push, history
+  rewrite, dropping a table, etc.). Committing and pushing your *own* branch and opening a PR are
+  reversible and non-destructive; force-push is not.
+- **Scope change** — the work turns out materially larger or different than the approved brief/goal.
+- **3-failed-attempts** — the 3-attempt rule fires (route to `/debug`, which itself runs inherited-
+  autonomous; see "How `/debug` behaves" below).
+
+A task **FAIL or BLOCKED** result also halts the run — that is a genuine block, not a checkpoint, and
+`--auto`'s "pause on failure" behavior is unchanged. `--autonomous` implies `--auto`.
+
+---
+
+## The decisions log
+
+Keep a running list of every self-answered decision. **Sink:** append to
+`tasks/stories/<id>/decisions-log.md` (create it if absent) — one line per decision:
+
+```
+- <question> → <chosen option> (reversible; <one-line why>)
+```
+
+Both the orchestrator and every inherited sub-skill/agent append to the **same** file. The
+orchestrator's PR step renders it verbatim under a **"Decisions made on your behalf"** section, so the
+reviewer sees every reversible call made without them. If a run has no story workspace (see below),
+keep the log inline in the conversation and hand it to the PR step directly.
+
+---
+
+## How the mode is inherited (the mechanism)
+
+A sub-skill or agent is a prompt, not code — it "inherits" the mode by **detecting a signal**. Two
+signals, checked in this order:
+
+1. **Invocation context (primary).** When an autonomous orchestrator invokes a sub-skill or spawns an
+   agent, it states in the invocation: *"This is an autonomous run — self-answer your checkpoints per
+   `rules/autonomous-mode.md` and append decisions to `tasks/stories/<id>/decisions-log.md`."* The
+   sub-skill honors that.
+2. **Durable marker (for standalone resume).** An autonomous orchestrator writes `run-mode:
+   autonomous` into `tasks/stories/<id>/executor-state.md`. A skill invoked **standalone** against an
+   existing story (e.g. `/run-tasks <id>` after a crash) reads that marker and inherits the mode even
+   though no live orchestrator is present.
+
+**Default = interactive.** A skill invoked directly by a human with **neither** signal present runs
+with all its normal STOP checkpoints. Autonomy is never assumed — it is only ever inherited from an
+explicit signal. Skills that do not operate on a story workspace (`/tdd`, `/debug` when run
+standalone) can only inherit via signal 1; run directly by a human they stay interactive, which is
+correct.
+
+---
+
+## No-op skills and agents
+
+Some invoked components have **no human checkpoints** and therefore need no autonomous behavior — the
+mode passes through them unchanged:
+
+- **`/local-test`** — pure verify-and-report; always reports its result back to the caller.
+- **Report-only review agents** — `evaluator-agent`, `acceptance-test-agent`,
+  `architect-reviewer-agent`, `security-reviewer-agent`. They return findings; they never pause for a
+  human. The **fix-vs-skip decision on their findings** lives in the orchestrator and is self-answered
+  there (a finding at/above the confidence threshold → fix and log; below → skip and log).
+
+These are documented as no-ops so it is explicit that "propagation" reached them and there was
+nothing to change.
+
+---
+
+## How `/debug` behaves under inherited autonomy
+
+`/debug` is the destination of the 3-attempt rule, so its inherited behavior is deliberate:
+
+- It **self-drives** the diagnosis: build the deterministic feedback loop, then self-select and test
+  hypotheses **one at a time**, reverting on failure. Each hypothesis test is reversible *because* the
+  feedback loop is deterministic, so it is self-answerable.
+- It **pauses (genuine block)** only when it cannot build a deterministic signal, or when all
+  hypotheses are exhausted (its 3-failed-hypotheses escalation).
+
+This preserves "pause only when genuinely blocked": the orchestrator's 3-attempt → `/debug` route
+tries a deterministic diagnosis first, and escalates to the human only if `/debug` itself cannot
+resolve it.
+
+---
+
+## One-line pattern for skills
+
+> This skill has no `--autonomous` flag. When it detects an inherited autonomous run (invocation
+> context, or `run-mode: autonomous` in the story's `executor-state.md`), it self-answers its own
+> STOP checkpoints per the self-answer rule above, logs each decision to the story's
+> `decisions-log.md`, and pauses only on a pause-anyway trigger. With neither signal it runs
+> interactively, exactly as before.

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -15,6 +15,35 @@ You are the diagnosis orchestrator. The 3-attempt rule has triggered — somethi
 
 ---
 
+## Autonomous mode (inherited — no flag of its own)
+
+`/debug` has **no `--autonomous` flag.** It inherits autonomous mode from its caller per
+`rules/autonomous-mode.md` — typically an autonomous `/implement` / `/run-tasks` reaching the
+3-attempt rule and routing here — detected via the invocation context. Run directly by a human with
+no such signal, it stays fully interactive, exactly as below.
+
+`/debug` is the **destination of the 3-attempt rule**, so its inherited behavior is deliberate: it
+**self-drives** the diagnosis rather than hard-pausing. The feedback loop makes each step reversible
+and deterministic, which is exactly what makes self-answering safe here.
+
+When the run is autonomous, apply the self-answer rule and log each hypothesis decision to the run's
+decisions log:
+
+- **Step 1b "can't build a feedback loop" A/B/C** → **pause (genuine block).** No deterministic
+  signal means no safe self-drive. This is one of the two places `/debug` stops for a human.
+- **Step 4 "choose a hypothesis" STOP** → self-select the **highest-confidence untested** hypothesis
+  and proceed; log the choice.
+- **Step 5 "say go" + one-change-at-a-time** → run the single change, run the feedback loop, and
+  **revert on FAIL** (reversible by construction). Continue down the ranked list one at a time.
+- **Step 5 "3 failed hypotheses" A/B/C** → **pause (genuine block).** Exhausting the ranked
+  hypotheses is a real escalation to the human — the second place `/debug` stops.
+
+Steps 6 (regression test) and 7 (instrumentation cleanup) are mandatory in every mode and are never
+skipped. The net effect: the 3-attempt → `/debug` route tries a deterministic diagnosis first, and
+the human is involved only when `/debug` itself cannot build a signal or cannot resolve the issue.
+
+---
+
 ## Step 1 — Build the feedback loop (THIS IS THE SKILL)
 
 Before any diagnosis begins, you need a **deterministic, agent-runnable pass/fail signal** — a single command that returns PASS or FAIL reliably and quickly.

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -87,12 +87,27 @@ A task **FAIL or BLOCKED** result also halts the run — that is a genuine block
 `--auto`'s "pause on failure" behavior is unchanged.
 
 **Decisions log.** Keep a running list of every self-answered decision as
-`- <question> → <chosen option> (reversible; <one-line why>)`. Accumulate it across all phases and
-surface it verbatim in the PR body under **"Decisions made on your behalf"** (Phase 3).
+`- <question> → <chosen option> (reversible; <one-line why>)`. Accumulate it across all phases in the
+shared sink `tasks/stories/<id>/decisions-log.md` (create it if absent) — inherited sub-skills append
+to the **same** file — and surface it verbatim in the PR body under **"Decisions made on your
+behalf"** (Phase 3).
 
-**Scope of this mode here:** `--autonomous` governs `/implement`'s own checkpoints only. Propagating
-the mode into invoked sub-skills (`/run-tasks`, `/tdd`, `/local-test`, `/debug`, evaluator agents) is
-a separate, follow-on task — until it lands, a sub-skill may still pause on its own checkpoint.
+**Propagation to sub-skills (inherited).** The full autonomous convention — the self-answer rule,
+pause-anyway triggers, decisions-log sink, and inheritance mechanism — is centralized in
+`rules/autonomous-mode.md`. Sub-skills and agents **inherit** the mode; they have **no `--autonomous`
+flag of their own**. When `--autonomous` is set, `/implement` propagates the mode two ways:
+1. **Invocation context** — every sub-skill/agent spawn below (`/local-test`, `/debug`, the executor
+   and review agents) is told, in its invocation, that this is an autonomous run and to self-answer
+   its checkpoints per `rules/autonomous-mode.md`, appending to the shared decisions-log.
+2. **Durable marker** — write `run-mode: autonomous` into `tasks/stories/<id>/executor-state.md` (the
+   file this flow already updates every wave), so a standalone resume (e.g. `/run-tasks <id>` after an
+   interruption) inherits the mode without a live orchestrator.
+
+`/local-test` and the review agents (evaluator / acceptance / architect / security) have no human
+checkpoints, so the mode is a **no-op** for them — they always report back and never pause; their
+findings' fix-vs-skip decision is self-answered here in Phase 3. `/debug` runs inherited-autonomous
+and **self-drives** the diagnosis, pausing only if it cannot build a deterministic signal or exhausts
+its hypotheses (see `rules/autonomous-mode.md`).
 
 Throughout the phases below, any block that says **STOP** is **auto-resolved by the self-answer rule
 above when `--autonomous` is set** — record the decision and proceed, unless a pause-anyway trigger fires.
@@ -297,7 +312,7 @@ For **each wave:**
 |---|---|---|---|
 | 1 | "..." | PASS/FAIL/BLOCKED | [one line] |
 
-**C2. Update the executor state:** Write/update `tasks/stories/<id>/executor-state.md` with the current progress table and wave log. Update after EVERY wave, not just at the end. This file is the resume state if the session is interrupted, and is read by `/improve-harness` for pattern detection. **In the same pass, mark each PASSed task `completed` in the `TodoWrite` list and mark the next wave's task(s) `in_progress`.** FAILed/BLOCKED tasks stay `in_progress` until resolved.
+**C2. Update the executor state:** Write/update `tasks/stories/<id>/executor-state.md` with the current progress table and wave log. Update after EVERY wave, not just at the end. This file is the resume state if the session is interrupted, and is read by `/improve-harness` for pattern detection. **In the same pass, mark each PASSed task `completed` in the `TodoWrite` list and mark the next wave's task(s) `in_progress`.** FAILed/BLOCKED tasks stay `in_progress` until resolved. **If `--autonomous` is set, include a `run-mode: autonomous` line in this file** so a standalone resume (`/run-tasks <id>`) inherits the mode (see the propagation contract in "Autonomous mode" above).
 
 **D. STOP after each wave (behavior depends on execution mode):**
 
@@ -377,7 +392,7 @@ Spawn a **`story-pr-agent`** (foreground) with:
 - Story ID: [issue ID or branch name]
 - Completed tasks: [list from Phase 2]
 - Branch: [current branch]
-- [If `--autonomous`] Decisions log: [the full running list of self-answered decisions] — the PR body MUST include a **"Decisions made on your behalf"** section rendering this list verbatim, so the reviewer sees every reversible call made without them.
+- [If `--autonomous`] Decisions log: the contents of `tasks/stories/<id>/decisions-log.md` (the shared sink that `/implement` **and** every inherited sub-skill appended to) — the PR body MUST include a **"Decisions made on your behalf"** section rendering this list verbatim, so the reviewer sees every reversible call made without them.
 
 Output the PR preparation report.
 
@@ -410,7 +425,7 @@ gh pr create --title "<title>" --body "<body from PR agent>"
 - `--full` expands to `--discuss --research` at parse time; it does NOT imply `--quick`, so `--full --quick` is a valid, meaningful combo
 - `--autonomous` skips only the **human STOP checkpoints** — it NEVER skips a phase, the goal definition, the evaluator/acceptance/e2e gate, local tests, or a failure pause; it implies `--auto` but NOT `--quick`, and it does not change any default or `--auto` behavior
 - In `--autonomous`, every self-answered decision is logged and surfaced in the PR under "Decisions made on your behalf"; the PR is opened non-draft as the single human gate
-- `--autonomous` here governs `/implement`'s own checkpoints only — propagating the mode into invoked sub-skills is a separate follow-on task
+- `--autonomous` propagates to invoked sub-skills and agents, which **inherit** the mode (no flag of their own) per `rules/autonomous-mode.md` — via invocation context plus a `run-mode: autonomous` marker in `executor-state.md`; `/local-test` and the review agents are no-ops, and `/debug` self-drives
 - For 1-2 file changes, don't over-decompose into multiple tasks
 - A task is only ✅ when its `<verify>` command passes — verify commands MUST include running relevant tests
 - If NOT ACCEPTED by the acceptance-test-agent, the feature is not done — fix before PR

--- a/skills/local-test/SKILL.md
+++ b/skills/local-test/SKILL.md
@@ -111,6 +111,16 @@ If any step fails:
 
 ---
 
+## Autonomous mode (inherited — no-op)
+
+`/local-test` has **no human checkpoints** — it verifies and always reports its result back to the
+caller, never pausing for a human. So an inherited autonomous run (per `rules/autonomous-mode.md`)
+passes through unchanged: there is nothing to self-answer here. It needs no `--autonomous` flag and no
+autonomous-specific behavior. This is documented as a no-op so it is explicit that propagation reached
+this skill and there was nothing to change.
+
+---
+
 ## Hard rules
 
 - Never modify source code — this skill only tests, never fixes

--- a/skills/run-tasks/SKILL.md
+++ b/skills/run-tasks/SKILL.md
@@ -18,6 +18,32 @@ You run the pending XML tasks for story **#[story ID]** from `tasks/stories/[sto
 
 ---
 
+## Autonomous mode (inherited — no flag of its own)
+
+`/run-tasks` has **no `--autonomous` flag.** It inherits autonomous mode from its caller per
+`rules/autonomous-mode.md`. Detect the mode via either signal: the invocation context (an autonomous
+`/implement` / `/story` says so when it hands off), or `run-mode: autonomous` in
+`tasks/stories/$ARGUMENTS/executor-state.md` (the standalone-resume path — read it in Step 2). With
+neither signal, run interactively exactly as below.
+
+When the run is autonomous, apply the self-answer rule from `rules/autonomous-mode.md` to this skill's
+checkpoints, and append each self-answered decision to `tasks/stories/$ARGUMENTS/decisions-log.md`:
+
+- **Step 2 "no goal defined" A/B** → self-answer **(A) define the goal** (reversible; a gate is
+  strictly better than none), run the Phase 1.5 goal step, log it. If the goal genuinely cannot be
+  defined without a human ruling, that is a pause-anyway trigger.
+- **Step 3 execution-mode A/B** → `--auto` is implied (autonomous implies `--auto`), so this question
+  never fires — use mode B.
+- **Step 4F wave STOP** → in mode B the wave pause already fires **only on FAIL/BLOCKED**, and that
+  stays: a FAIL/BLOCKED is a genuine block, not a checkpoint. All-passed waves auto-continue.
+- **Step 6 goal gate** → already deterministic; on failure it re-approaches and escalates to `/debug`
+  (inherited-autonomous) per the 3-attempt rule — unchanged.
+
+The mode never skips a phase, the goal gate, local tests, or a failure pause. Pause only on a
+pause-anyway trigger (contradiction, irreversible action, scope change, 3-failed-attempts).
+
+---
+
 ## Step 1 — Find the task plan
 
 Read `YOUR_PROJECT_ROOT\tasks\stories\$ARGUMENTS\plan.md` — the always-local story plan that `/story` and `/implement` write. It is the source of truth for the task plan in **every** tracker mode; `todo.md` is only a generated dashboard and never holds the XML plan.
@@ -38,6 +64,10 @@ cd YOUR_PROJECT_ROOT && git status && git branch --show-current
 ```
 
 Confirm you are on the correct feature branch for story #$ARGUMENTS. If you are on `master`, say so and ask YOUR_NAME to confirm the branch before continuing.
+
+**Autonomous check:** read `tasks/stories/$ARGUMENTS/executor-state.md` — if it contains `run-mode:
+autonomous`, this is an inherited autonomous run (see "Autonomous mode" above); otherwise run
+interactively.
 
 **Goal check:** Read `tasks/stories/$ARGUMENTS/test-strategy.md` (or `tasks/stories/$ARGUMENTS/plan.md` if no test-strategy exists). Look for a defined e2e gate / acceptance criteria / goal definition.
 

--- a/skills/tdd/SKILL.md
+++ b/skills/tdd/SKILL.md
@@ -15,6 +15,30 @@ You are the TDD facilitator. Your job is to guide the user through strict RED-GR
 
 ---
 
+## Autonomous mode (inherited — no flag of its own)
+
+`/tdd` has **no `--autonomous` flag.** It inherits autonomous mode from its caller per
+`rules/autonomous-mode.md`, detected via the invocation context (an autonomous orchestrator says so
+when it delegates). `/tdd` has no story workspace of its own, so the durable `run-mode` marker does
+not apply — run directly by a human with no such signal, it stays fully interactive, exactly as below.
+
+When the run is autonomous, apply the self-answer rule from `rules/autonomous-mode.md` to this skill's
+gates, logging each self-answered decision to the run's decisions log:
+
+- **Step 2 pre-flight (interface + behavior list approval)** → propose the interface and the
+  prioritized behavior list and **adopt them** (reversible; a proposed slice is refinable next
+  cycle), log the adoption, and proceed. If the interface is genuinely ambiguous in a way that
+  changes scope, that is a pause-anyway trigger.
+- **Step 3 per-cycle checkpoint (A/B/C/D)** → self-answer **(A) continue to next behavior** and run
+  cycles back-to-back until every behavior is implemented, then finish at Step 4. Do not stop for
+  "review"/"adjust" prompts.
+
+Pause only on a genuine block: a test that cannot be made to pass after honest attempts, or a
+required interface change that materially alters scope. The RED-GREEN-REFACTOR discipline, regression
+runs, and vertical-slicing rules are never relaxed by the mode.
+
+---
+
 ## Step 0 — Register in task files
 
 Before doing anything else, write an in-progress breadcrumb to `tasks/notes.md` — in every pack and mode:


### PR DESCRIPTION
## What & why

Realizes the "Autonomous pipeline mode" milestone increment in two stacked commits:

1. **`fee31eb`** — adds the `--autonomous` flag to `/implement` (prior task, p1).
2. **`d6a507c`** — propagates that mode into the invoked sub-skills (this task, p2).

Per grill decision **fork 6**, sub-skills **inherit** autonomous mode — they get **no `--autonomous`
flag of their own**. This PR makes each sub-skill honor the mode it runs under so an autonomous
`/implement` run no longer stalls at a sub-skill's own human checkpoint.

## Changes

- **NEW `rules/autonomous-mode.md`** — single source of truth for the convention: the self-answer
  rule, pause-anyway triggers (contradiction / irreversible / scope change / 3-failed-attempts), the
  shared decisions-log sink, the two inheritance signals (invocation context + `run-mode: autonomous`
  marker in `executor-state.md`; interactive by default), and the no-op clause.
- **`/run-tasks`** — "Autonomous mode (inherited)" section: self-answers the Step-2 goal A/B; the
  wave FAIL/BLOCKED pause **persists** (genuine block, not a checkpoint); reads the marker on
  standalone resume.
- **`/tdd`** — self-answers the pre-flight interface/behavior approval and the per-cycle checkpoint
  (→ continue); inherits via invocation context only (no story workspace).
- **`/debug`** — **self-drives** diagnosis: builds the deterministic feedback loop, tests hypotheses
  one at a time (revert on fail), and pauses only if it cannot build a signal or exhausts its
  hypotheses. Preserves "pause only when genuinely blocked" while letting the machine try first.
- **`/local-test`** and the review agents (evaluator / acceptance / architect / security) —
  documented **no-ops** (no human checkpoints; always report back).
- **`/implement`** — replaces the "separate follow-on task" caveat and its matching hard-rule with
  the real propagation contract (invocation context + marker write + shared decisions-log rendered in
  the PR).

## Design decisions (confirmed with the author)

- Inheritance mechanism: invocation context + durable `run-mode: autonomous` marker.
- `/debug`: self-drives, pauses only on genuine block.
- Convention centralized in one rule file, referenced by each skill (no copy-paste drift).
- Scope: the grill's five skills only; `/troubleshoot` is a noted fast follow-up.

## Verification

- Doc-consistency probe — **34/34 assertions GREEN**, including regression checks that every edited
  skill retains its default-path STOP blocks verbatim.
- `shellcheck` clean on the probe script.
- No code changed → no build/unit target; no new flag on any sub-skill (fork-6 asserted).
- `.claude/*` are symlinks to repo root, so the dogfood copies update automatically (verified same
  inode) — no mirror edits.

## Out of scope (tracked separately)

- `/story` parity — Todoist `6h76rgWHJ3Q9g7qg`
- README/CHANGELOG docs — Todoist `6h76rgjpwFj5fqfg`
- `/troubleshoot` inheritance — fast follow-up