### PR TITLE
feat(implement): add --rework PR feedback-loop mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,13 +5,14 @@
   "description": "Dev-only manifest for tests and lint. Not copied by the installer; runtime stays zero-dep.",
   "scripts": {
     "dogfood": "node scripts/dogfood.js",
-    "test": "node --test hooks/__tests__/*.test.js trackers/__tests__/*.test.js code-platform/__tests__/*.test.js install/__tests__/*.test.js",
+    "test": "node --test hooks/__tests__/*.test.js trackers/__tests__/*.test.js code-platform/__tests__/*.test.js install/__tests__/*.test.js skills/*/__tests__/*.test.js",
     "test:hooks": "node --test hooks/__tests__/*.test.js",
     "test:trackers": "node --test trackers/__tests__/*.test.js",
     "test:code-platform": "node --test code-platform/__tests__/*.test.js",
     "test:install": "node --test install/__tests__/*.test.js",
-    "test:coverage": "c8 --reporter=text --reporter=lcov node --test hooks/__tests__/*.test.js trackers/__tests__/*.test.js code-platform/__tests__/*.test.js install/__tests__/*.test.js",
-    "lint": "eslint hooks/ trackers/__tests__/ code-platform/__tests__/ install/",
+    "test:skills": "node --test skills/*/__tests__/*.test.js",
+    "test:coverage": "c8 --reporter=text --reporter=lcov node --test hooks/__tests__/*.test.js trackers/__tests__/*.test.js code-platform/__tests__/*.test.js install/__tests__/*.test.js skills/*/__tests__/*.test.js",
+    "lint": "eslint hooks/ trackers/__tests__/ code-platform/__tests__/ install/ skills/*/__tests__/",
     "typecheck": "tsc --noEmit"
   },
   "engines": {

--- a/rules/autonomous-mode.md
+++ b/rules/autonomous-mode.md
@@ -5,6 +5,15 @@ This file is the **single source of truth** for how autonomous mode behaves acro
 work — `/story`). Every sub-skill and agent an orchestrator invokes **inherits** the mode; sub-skills
 have **no `--autonomous` flag of their own** (grill decision, fork 6).
 
+**Explicit autonomous entry points.** Autonomy always begins at an *explicit* signal (never assumed —
+see "How the mode is inherited" below). There are two kinds: `--autonomous` on an orchestrator (the
+forward flow), and `--rework <PR#>` on `/implement` (the reject-loop that re-enters an open PR). Both
+are direct, human-typed flags whose presence *is* the signal, so both run under the self-answer rule
+without contradicting "autonomy is only ever inherited from a signal" — the flag itself is that signal.
+`--rework` is **not** a second `--autonomous`-style flag on sub-skills; it is a mode selector on the
+orchestrator that happens to imply autonomous semantics. A rework run is keyed by PR number and has no
+story workspace, so its decisions log stays inline (see the decisions-log section).
+
 **Location:** `rules/autonomous-mode.md` (installed alongside `.claude/skills/`; the `.claude/` copy
 is a symlink to this file).
 **Referenced by:** `skills/implement/SKILL.md`, `skills/run-tasks/SKILL.md`, `skills/tdd/SKILL.md`,
@@ -78,10 +87,13 @@ signals, checked in this order:
    though no live orchestrator is present.
 
 **Default = interactive.** A skill invoked directly by a human with **neither** signal present runs
-with all its normal STOP checkpoints. Autonomy is never assumed — it is only ever inherited from an
-explicit signal. Skills that do not operate on a story workspace (`/tdd`, `/debug` when run
-standalone) can only inherit via signal 1; run directly by a human they stay interactive, which is
-correct.
+with all its normal STOP checkpoints. Autonomy is never assumed — it is only ever triggered by an
+explicit signal. Alongside the two inheritance signals above, a **human-typed autonomous entry flag is
+itself an explicit signal**: `--autonomous` on an orchestrator, or `--rework <PR#>` on `/implement`,
+each turns that same run autonomous directly (no upstream orchestrator required) — this is consistent
+with "never assumed," because the flag the human typed *is* the signal. Skills that do not operate on a
+story workspace (`/tdd`, `/debug` when run standalone) can only inherit via signal 1; run directly by a
+human with no flag they stay interactive, which is correct.
 
 ---
 

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: implement
-description: Build a feature from a tracker task (local task, GitHub issue, or Todoist task) or plain description — understand, plan, execute, evaluate, and PR in a streamlined flow. Lighter than /story — designed for solo devs and small teams. Usage: /implement <issue-id, task-title, or description> [--discuss] [--research] [--quick] [--auto] [--full] [--autonomous]
-argument-hint: "#42, 'Build login flow', or 'add dark mode to settings page'"
+description: Build a feature from a tracker task (local task, GitHub issue, or Todoist task) or plain description — understand, plan, execute, evaluate, and PR in a streamlined flow, or loop back on a rejected PR with `--rework <PR#>`. Lighter than /story — designed for solo devs and small teams. Usage: /implement <issue-id, task-title, or description> [--discuss] [--research] [--quick] [--auto] [--full] [--autonomous] [--rework <PR#>]
+argument-hint: "#42, 'Build login flow', 'add dark mode to settings page', or --rework 58 'also rename the flag'"
 ---
 
 **Core Philosophy:** Understand it, plan it, build it, check it, ship it — with a human gate at each step. Like `/story` but without the sprint ceremony.
@@ -25,6 +25,8 @@ cd YOUR_PROJECT_ROOT && git status && git branch --show-current
 ```
 
 Parse `$ARGUMENTS`:
+
+0. **Detect `--rework <PR#>` first — this is a MODE SELECTOR, not an additive flag.** If `$ARGUMENTS` starts with (or contains) `--rework <PR#>`, where `<PR#>` is the numeric PR number, extract it and treat any remaining free text after it as optional typed feedback. **Validate that `<PR#>` matches `^[0-9]+$` before using it anywhere** — if it is missing or non-numeric, stop and ask; never pass an unvalidated `<PR#>` into a `gh` command or a script argument. Unlike `--discuss`/`--research`/`--quick`/`--auto`/`--full`/`--autonomous` (which combine with the normal build flow), `--rework` **short-circuits** the entire Understand → Plan → Build → PR flow below and jumps straight to the Rework mode section further down this file. `--rework` is itself an **explicit autonomous entry point** — invoking the flag *is* the signal (the same role `--autonomous` plays for the forward flow), so it runs under the self-answer rule of `rules/autonomous-mode.md` without needing a separate `--autonomous`. If `--rework` is detected, skip steps 1-4 below and the branch-creation step, and go directly to that section.
 
 1. **Extract flags** into a set (strip them out before interpreting the rest):
    - `--discuss` → run a pre-plan clarification step (Phase 1a)
@@ -111,6 +113,105 @@ its hypotheses (see `rules/autonomous-mode.md`).
 
 Throughout the phases below, any block that says **STOP** is **auto-resolved by the self-answer rule
 above when `--autonomous` is set** — record the decision and proceed, unless a pause-anyway trigger fires.
+
+---
+
+## Rework mode (only if `--rework <PR#>` is set)
+
+`--rework <PR#>` loops `/implement` back onto an already-open, already-reviewed PR instead of starting
+a fresh build — mirroring the fetch → analyze → fix → reply → resolve pattern of
+`skills/babysit-pr/SKILL.md`, but driving straight through it under autonomous self-answer semantics
+(no gates until the push) rather than pausing at babysit-pr's four GATEs. `--rework` is an explicit
+autonomous entry point in its own right (see step 0) — the flag is the signal, so this is not an
+"inherited" run and needs no `--autonomous`.
+
+**a. No fresh build.** On a valid `--rework`, do **not** run Phase 1 (Understand), Phase 1.5 (Goal
+Definition), or Phase 1c (Plan). Do **not** create a new branch. Do **not** open a new PR.
+
+**b. Check out the PR's existing head branch.** First confirm the PR's head is in *this* repo, not a
+fork — a cross-repo (fork) head branch name is not fork-qualified, so a later push could silently land
+on a same-named branch of `origin` instead of the contributor's fork:
+
+```bash
+gh pr view <PR#> --json isCrossRepository,headRefName,headRepositoryOwner
+```
+
+If `isCrossRepository` is `true`, **treat it as a pause-anyway trigger and stop** — you cannot safely
+push to a fork's branch from here; ask the human. Otherwise check out the head branch:
+
+```bash
+HEAD_BRANCH=$(gh pr view <PR#> --json headRefName -q .headRefName)
+git checkout "$HEAD_BRANCH"
+```
+
+Never create a new branch with `checkout` for this step — this is the same branch the open PR already tracks, not a new one.
+
+**c. Fetch unresolved review threads.**
+
+```bash
+bash "YOUR_PROJECT_ROOT/.claude/code-platform/active/get-pr-review-threads.sh" <PR#>
+```
+
+Returns JSON `[{id, threadId, file, line, content, author}]`, already filtered to unresolved threads.
+If the result is `[]`/empty **and** no typed feedback was given after `<PR#>`, say **"No unresolved
+threads on PR #<PR#> and no typed feedback — nothing to rework."** and stop.
+
+**d. Merge into one ordered fix list.** Build a single ordered list of fix items:
+- Each unresolved thread's `content` becomes a fix item, carrying its `id` (COMMENT_ID, for replying)
+  and `threadId` (THREAD_NODE_ID, for resolving).
+- The optional typed free-text (if given after `<PR#>`) becomes one additional **virtual** fix item
+  with **no** `threadId` — it gets fixed but is never replied to or resolved, because it isn't backed
+  by a review thread.
+
+**e. Apply the fixes.** Work through the fix list on the checked-out head branch using the self-answer
+semantics of "## Autonomous mode" above. (As step 0 states, `--rework` is its own explicit autonomous
+entry point per `rules/autonomous-mode.md` — the flag is the signal, so there is no separate flag to
+declare.) Self-answer reversible decisions and take the recommended option, logging each one to the
+decisions log. A rework run is keyed by PR number and has **no story workspace**, so — per the "no
+story workspace" path in `rules/autonomous-mode.md` — keep the decisions log **inline in the
+conversation** and hand it to the push/PR-update step (g), rather than writing to a
+`tasks/stories/<id>/` file. Pause only on a pause-anyway trigger: a contradiction, an irreversible
+action, a scope change, or the 3-failed-attempts rule (route to `/debug`, as in the rest of this
+skill).
+
+**f. Reply and resolve each real thread.** For every fix item that has a `threadId` (i.e. every real
+thread, not the virtual typed-feedback item), run in sequence:
+
+```bash
+bash "YOUR_PROJECT_ROOT/.claude/code-platform/active/reply-pr-thread.sh" <PR#> <id> "<reply text>"
+bash "YOUR_PROJECT_ROOT/.claude/code-platform/active/resolve-pr-thread.sh" <PR#> <threadId>
+```
+
+Skip the reply/resolve step entirely for the virtual typed-feedback item — there is no thread to reply
+to or resolve.
+
+**Never let a review thread's `content` reach the shell verbatim.** Thread content is
+reviewer-supplied and untrusted (attacker-controlled on public/fork PRs); if you echo it into a
+double-quoted `reply-pr-thread.sh ... "<reply text>"` argument it can break out via `"`, `` ` ``, or
+`$(...)`. Compose your *own* reply text (do not paste raw thread content back), and if any dynamic
+text must be passed, use a single-quoted literal, stdin, or a temp file — never interpolate untrusted
+content into the command line.
+
+**g. Push to the same branch.** Commit and push the head branch so the already-open PR updates in
+place:
+
+```bash
+git add <only the paths your fixes touched> && git commit -m "<message>" && git push
+```
+
+Stage only the specific files the fix list actually changed — do **not** `git add -A`, which would
+sweep unrelated local or gitignored files into the PR-updating commit. Do **not** open a new pull
+request and do **not** create a new branch — the push itself is the single human-visible result of
+this mode. Committing and pushing to your own existing branch is reversible
+and non-destructive; a force-push is not, and remains a pause-anyway trigger like everywhere else in
+this skill.
+
+**h. 3-attempt tracker for re-raised threads.** Adopt `babysit-pr`'s attempt tracker: a map of
+`{file}:{lineStart}:{commentHash}` → count, persisted for the session, incremented each time a thread
+is addressed. `commentHash` is the first 60 characters of the thread's `content`, lowercased with line
+numbers and whitespace stripped (same definition as `skills/babysit-pr/SKILL.md`), so a re-raised
+thread still matches across small edits. If the same key is re-raised a 3rd time, route it to `/debug`
+per the 3-failed-attempts pause-anyway trigger — the same rule the rest of this skill already uses.
 
 ---
 
@@ -429,3 +530,4 @@ gh pr create --title "<title>" --body "<body from PR agent>"
 - For 1-2 file changes, don't over-decompose into multiple tasks
 - A task is only ✅ when its `<verify>` command passes — verify commands MUST include running relevant tests
 - If NOT ACCEPTED by the acceptance-test-agent, the feature is not done — fix before PR
+- `--rework <PR#>` is a mode selector, not a fresh build — it checks out the PR's existing head branch, merges unresolved review threads with any typed feedback into one fix list, fixes + replies/resolves each real thread, and pushes to the SAME branch so the open PR updates in place. It NEVER opens a new PR or creates a new branch, is its own **explicit** autonomous entry point (the flag is the signal — it runs under the self-answer rule of `rules/autonomous-mode.md`, no `--autonomous` needed), and pauses only on a pause-anyway trigger.

--- a/skills/implement/__tests__/rework-mode.probe.test.js
+++ b/skills/implement/__tests__/rework-mode.probe.test.js
@@ -1,0 +1,112 @@
+// Doc-consistency probe for `--rework <PR#>` mode in skills/implement/SKILL.md.
+//
+// This is not a code test — it's a probe that asserts the SKILL.md prose stays internally
+// consistent as the file evolves: frontmatter mentions --rework, a dedicated Rework mode
+// section exists, it only references scripts that actually exist on disk, it never opens a
+// new PR/branch, the Hard rules section documents it, and none of the pre-existing flags/STOP
+// tokens regressed.
+
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
+const SKILL_PATH = path.join(REPO_ROOT, 'skills', 'implement', 'SKILL.md');
+
+const SKILL_MD = fs.readFileSync(SKILL_PATH, 'utf8');
+
+function extractFrontmatter(content) {
+  const lines = content.split('\n');
+  const dashIndices = [];
+  for (let i = 0; i < lines.length && dashIndices.length < 2; i++) {
+    if (lines[i].trim() === '---') dashIndices.push(i);
+  }
+  if (dashIndices.length < 2) return null;
+  return lines.slice(dashIndices[0] + 1, dashIndices[1]).join('\n');
+}
+
+function extractReworkSection(content) {
+  const match = content.match(/## Rework mode[\s\S]*?(?=\n## )/);
+  return match ? match[0] : null;
+}
+
+function extractHardRulesSection(content) {
+  const idx = content.indexOf('## Hard rules');
+  if (idx === -1) return null;
+  return content.slice(idx);
+}
+
+const FRONTMATTER = extractFrontmatter(SKILL_MD);
+const REWORK_SECTION = extractReworkSection(SKILL_MD);
+const HARD_RULES_SECTION = extractHardRulesSection(SKILL_MD);
+
+test('ReworkSection_Exists', () => {
+  assert.ok(REWORK_SECTION, 'Expected a "## Rework mode" section followed by another "## " heading, but none was found');
+});
+
+test('Frontmatter_MentionsReworkInDescriptionAndArgumentHint', () => {
+  assert.ok(FRONTMATTER, 'Expected a frontmatter block delimited by the first two "---" lines');
+  const descriptionLine = FRONTMATTER.split('\n').find((l) => l.startsWith('description:'));
+  const argumentHintLine = FRONTMATTER.split('\n').find((l) => l.startsWith('argument-hint:'));
+  assert.ok(descriptionLine, 'Expected a description: line in frontmatter');
+  assert.ok(argumentHintLine, 'Expected an argument-hint: line in frontmatter');
+  assert.match(descriptionLine, /--rework/, 'description: usage string must mention --rework');
+  assert.match(argumentHintLine, /--rework/, 'argument-hint: must mention --rework');
+});
+
+test('ArgParsing_DefinesReworkWithPRNumber', () => {
+  const matchesRegex = /--rework\s+<?PR/i.test(SKILL_MD);
+  const matchesBullet = /--rework\s*<PR#>/.test(SKILL_MD);
+  assert.ok(matchesRegex || matchesBullet, 'Expected the SKILL.md body to define "--rework <PR#>" (via arg-parsing regex or a bullet)');
+});
+
+test('ReworkSection_ReferencesOnlyScriptsThatExistOnDisk', () => {
+  assert.ok(REWORK_SECTION, 'Rework mode section must exist to check its script references');
+
+  const requiredScripts = ['get-pr-review-threads.sh', 'reply-pr-thread.sh', 'resolve-pr-thread.sh'];
+  for (const script of requiredScripts) {
+    assert.ok(REWORK_SECTION.includes(script), `Rework mode section must mention ${script}`);
+  }
+
+  const mentionedScripts = new Set(REWORK_SECTION.match(/[\w-]+\.sh/g) || []);
+  assert.ok(mentionedScripts.size > 0, 'Expected at least one .sh script mentioned in the Rework mode section');
+
+  for (const script of mentionedScripts) {
+    const inGithubAdapter = fs.existsSync(path.join(REPO_ROOT, 'code-platform', 'github', script));
+    const inActiveAdapter = fs.existsSync(path.join(REPO_ROOT, '.claude', 'code-platform', 'active', script));
+    assert.ok(
+      inGithubAdapter || inActiveAdapter,
+      `Rework mode section mentions "${script}" but it does not exist under code-platform/github/ or .claude/code-platform/active/`
+    );
+  }
+});
+
+test('ReworkSection_NeverOpensNewPrOrBranch', () => {
+  assert.ok(REWORK_SECTION, 'Rework mode section must exist to check for new-PR/new-branch commands');
+  // Guard the INTENT ("never opens a new PR/branch"), not just two literal spellings — cover the
+  // common alternate forms an edit might reach for.
+  const forbiddenNewPr = [/gh\s+pr\s+create\b/, /gh\s+pr\s+new\b/];
+  const forbiddenNewBranch = [/checkout\s+-b\b/, /switch\s+-c\b/, /switch\s+--create\b/, /worktree\s+add\b/];
+  for (const re of forbiddenNewPr) {
+    assert.doesNotMatch(REWORK_SECTION, re, `Rework mode must never open a new PR (matched ${re}) — it updates the existing PR in place`);
+  }
+  for (const re of forbiddenNewBranch) {
+    assert.doesNotMatch(REWORK_SECTION, re, `Rework mode must never create a new branch (matched ${re}) — it checks out the PR's existing head branch`);
+  }
+});
+
+test('HardRules_MentionsRework', () => {
+  assert.ok(HARD_RULES_SECTION, 'Expected a "## Hard rules" section');
+  assert.match(HARD_RULES_SECTION, /--rework/, 'Hard rules section must document --rework');
+});
+
+test('Regression_ExistingStopTokensAndFlagsStillPresent', () => {
+  const requiredTokens = [
+    'STOP 1', 'STOP 1.5', 'STOP 3',
+    '--discuss', '--research', '--quick', '--auto', '--full', '--autonomous',
+  ];
+  for (const token of requiredTokens) {
+    assert.ok(SKILL_MD.includes(token), `Expected SKILL.md to still contain "${token}"`);
+  }
+});


### PR DESCRIPTION
## What & why
Adds the **reject-loop half of the PR gate** to `/implement`. `--rework <PR#> [typed feedback]` reads a PR's unresolved review threads, merges them with any typed feedback into one ordered fix list, checks out the PR's **existing** head branch, fixes with autonomous self-answer semantics, replies+resolves each real thread, and pushes so the open PR updates **in place** — no new branch, no new PR, no gates until push. Completes the **"--autonomous + --rework"** milestone (Todoist `6h76rgfwQqg5CwV8`).

## Changes
- **`skills/implement/SKILL.md`** — frontmatter usage + `argument-hint`, a `--rework` mode-selector branch in arg parsing, a new **Rework mode** section (reuses the existing `code-platform` PR-thread scripts + the Autonomous mode self-answer contract), and a Hard-rules bullet.
- **`rules/autonomous-mode.md`** — sanctions `--autonomous` and `--rework` as the two **explicit** autonomous entry flags (the human-typed flag *is* the signal — consistent with "autonomy is never assumed, only triggered by a signal").
- **`skills/implement/__tests__/rework-mode.probe.test.js`** — 7-assertion doc-consistency probe (the concrete gate); wired into `npm test`/coverage.
- **`package.json`** — `skills/*/__tests__` added to test/coverage/lint globs (single-`*` form for CI `dash` portability, not `**`).

## Review hardening (evaluator / architect / security advisories, all applied)
- `--rework` framed as an explicit autonomy trigger (was wrongly "inherited by default", which contradicted the autonomy rule — the one BLOCK finding).
- validate `<PR#>` matches `^[0-9]+$` before use; never let untrusted review-thread content reach the shell verbatim; cross-repo/fork PR is a pause trigger; stage only touched paths.
- define the 3-attempt `commentHash`; broaden the no-new-PR/branch probe guard beyond two literals.

## Verification
- Probe **7/7**, `npm test` **426/426**, `npm run lint` clean.
- Dry-run vs real PR #59: fork-guard (`isCrossRepository=false`) + thread-fetch (`[]`) + empty short-circuit proven against live GitHub. The full fix→reply→resolve→push loop is human-accepted — no in-repo PR carries unresolved review threads to exercise it; it runs naturally the first time `--rework` targets a PR with real reviewer comments.

## Notes
- Sibling `--autonomous` parity for `/story` is tracked separately (Todoist `6h76rgWHJ3Q9g7qg`); docs for the whole milestone are Todoist `6h76rgjpwFj5fqfg`.
