### PR TITLE
fix: align solo pack's skill and agent rosters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). This project adh
 
 ## [Unreleased]
 
+### Fixed
+
+- **Solo installs no longer ship skills that spawn uninstalled agents.** `/implement` and `/run-tasks` spawn `story-understand-agent`, `story-executor-agent`, and `story-pr-agent` by name, but all three were on the enterprise-only skip list — so a solo install had skills pointing at agents that were never copied. The three now ship in both packs (only `story-plan-agent` and the `sprint-plan-*` agents stay enterprise-only). Existing solo installs pick them up on `/update-harness`.
+- **Skills are now pack-filtered.** Previously *every* skill was copied to *every* install, so solo users received `/story` and `/sprint-plan` — which depend on the enterprise-only agents and cannot run in a solo install. Solo installs now omit both, and `--update` prunes them from installs made before this change.
+- **Install verification catches roster drift.** `verifyInstall` now asserts that every agent a pack's skills spawn is present, and that no enterprise-only skill leaked into a solo install — so this class of mismatch fails at install time instead of surfacing mid-run.
+
+### Changed
+
+- **Autonomous mode: a missing dependency is a pause-anyway trigger.** A named skill, agent, script, or tracker adapter that is not installed now stops an autonomous run instead of being self-answered. Substituting a `general-purpose` agent for a purpose-built one is explicitly forbidden: an agent definition is a quality contract, so replacing it changes *what work was done*, not just how — which fails the reversibility test. Previously such a substitution passed the self-answer rule and was disclosed only as a line in the decisions log. See `rules/autonomous-mode.md`.
+
 ---
 
 ## [3.2.0] - 2026-07-25

--- a/README.md
+++ b/README.md
@@ -288,17 +288,20 @@ Skills are invoked with `/skill-name` in Claude Code. Each skill is a folder und
 | **implement** | `/implement #42` or `/implement "add dark mode"` | Build a feature from issue or description — plan, execute, evaluate, PR |
 | **plan** | `/plan` | Read open issues, prioritize, create a simple work plan |
 
-### Enterprise workflow (4 skills)
+### Enterprise workflow (2 skills)
+
+These are the only skills the solo pack does **not** install — they drive the sprint/story lifecycle and spawn enterprise-only agents.
+
 | Skill | Usage | What it does |
 |---|---|---|
 | **story** | `/story <ID>` | 8-phase story lifecycle: understand → define goal → plan → execute → local verify → review → e2e gate → PR |
 | **sprint-plan** | `/sprint-plan <N>` | Sprint planning — reads tracker, writes sprint file, surfaces gaps |
-| **babysit-pr** | `/babysit-pr <PR>` | Drive a PR to zero review threads |
-| **run-tasks** | `/run-tasks <ID>` | Resume story execution (Phase 3 only) |
 
 ### Shared skills (both packs)
 | Skill | Usage | What it does |
 |---|---|---|
+| **run-tasks** | `/run-tasks <ID>` | Resume task execution from a story plan — the resume path for both `/implement` and `/story` |
+| **babysit-pr** | `/babysit-pr <PR>` | Drive a PR to zero review threads |
 | **evaluate** | `/evaluate` | Adversarial quality check before PR |
 | **debug** | `/debug` (alias: `/diagnose`) | Feedback-loop-first diagnosis — builds a deterministic pass/fail signal, then tests ranked falsifiable hypotheses one at a time |
 | **troubleshoot** | `/troubleshoot` | Deep behavioral bug investigation (up to 5 iterations) |

--- a/install/__tests__/non-interactive.test.js
+++ b/install/__tests__/non-interactive.test.js
@@ -15,13 +15,22 @@ const REPO = path.resolve(__dirname, '..', '..');
 const LOCAL = ['--local', REPO];
 
 const ENTERPRISE_ONLY_AGENTS = [
-  'story-understand-agent.md',
   'story-plan-agent.md',
-  'story-executor-agent.md',
-  'story-pr-agent.md',
   'sprint-plan-gap-analyzer.md',
   'sprint-plan-docs-reader.md',
   'sprint-plan-tracker-reader.md',
+];
+
+const ENTERPRISE_ONLY_SKILLS = ['story', 'sprint-plan'];
+
+// Agents that solo-pack skills (/implement, /run-tasks) spawn by name. Skipping
+// any of these in the solo pack leaves those skills pointing at agents that were
+// never installed — the roster drift this list guards against.
+const SOLO_REQUIRED_AGENTS = [
+  'implement-planner-agent.md',
+  'story-understand-agent.md',
+  'story-executor-agent.md',
+  'story-pr-agent.md',
 ];
 
 function makeTempProject() {
@@ -79,6 +88,123 @@ test('install.js --yes --project installs without enterprise agents', () => {
       );
     }
     assert.ok(agents.length > 0, 'should install some agents');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('install.js solo install ships every agent its skills spawn by name', () => {
+  const dir = makeTempProject();
+  try {
+    runInstallJs(['--yes', '--project', dir, ...LOCAL]);
+    const agents = fs.readdirSync(path.join(dir, '.claude', 'agents'));
+    for (const required of SOLO_REQUIRED_AGENTS) {
+      assert.ok(
+        agents.includes(required),
+        `${required} is spawned by a solo-pack skill and must be installed in solo mode`,
+      );
+    }
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('install.js solo install omits enterprise-only skills', () => {
+  const dir = makeTempProject();
+  try {
+    runInstallJs(['--yes', '--project', dir, ...LOCAL]);
+    const skills = fs.readdirSync(path.join(dir, '.claude', 'skills'));
+    for (const skill of ENTERPRISE_ONLY_SKILLS) {
+      assert.ok(
+        !skills.includes(skill),
+        `enterprise skill /${skill} should not be installed in solo mode`,
+      );
+    }
+    assert.ok(skills.includes('implement'), 'solo pack must ship /implement');
+    assert.ok(skills.includes('run-tasks'), 'solo pack must ship /run-tasks');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('install.js enterprise install ships enterprise skills and agents', () => {
+  const dir = makeTempProject();
+  try {
+    runInstallJs(['--yes', '--project', dir, '--pack', 'enterprise', ...LOCAL]);
+    const skills = fs.readdirSync(path.join(dir, '.claude', 'skills'));
+    const agents = fs.readdirSync(path.join(dir, '.claude', 'agents'));
+    for (const skill of ENTERPRISE_ONLY_SKILLS) {
+      assert.ok(skills.includes(skill), `enterprise pack must ship /${skill}`);
+    }
+    for (const agent of [...ENTERPRISE_ONLY_AGENTS, ...SOLO_REQUIRED_AGENTS]) {
+      assert.ok(agents.includes(agent), `enterprise pack must ship ${agent}`);
+    }
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('every agent spawned by an installed solo skill exists in the solo install', () => {
+  const dir = makeTempProject();
+  try {
+    runInstallJs(['--yes', '--project', dir, ...LOCAL]);
+    const claudeDir = path.join(dir, '.claude');
+    const agents = new Set(
+      fs.readdirSync(path.join(claudeDir, 'agents')).map((f) => f.replace(/\.md$/, '')),
+    );
+    const skillsDir = path.join(claudeDir, 'skills');
+    const missing = [];
+    for (const skill of fs.readdirSync(skillsDir)) {
+      const skillFile = path.join(skillsDir, skill, 'SKILL.md');
+      if (!fs.existsSync(skillFile)) continue;
+      const text = fs.readFileSync(skillFile, 'utf8');
+      // Matches the skills' own convention for naming an agent to spawn:
+      // "Spawn a **`story-pr-agent`**" / "spawn a `story-executor-agent`".
+      for (const m of text.matchAll(/spawn(?:ing)?\s+(?:each\s+as\s+)?an?\s+\*{0,2}`([a-z0-9-]+-agent)`/gi)) {
+        if (!agents.has(m[1])) missing.push(`skills/${skill} spawns ${m[1]}`);
+      }
+    }
+    assert.deepStrictEqual(missing, [], `solo install has skills spawning uninstalled agents:\n${missing.join('\n')}`);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('update migrates a pre-pack-filter solo install: prunes enterprise skills, restores story agents', () => {
+  const dir = makeTempProject();
+  try {
+    runInstallJs(['--yes', '--project', dir, ...LOCAL]);
+    const claudeDir = path.join(dir, '.claude');
+
+    // Regress to the pre-fix shape: enterprise skills present, story agents absent.
+    for (const skill of ENTERPRISE_ONLY_SKILLS) {
+      fs.cpSync(path.join(REPO, 'skills', skill), path.join(claudeDir, 'skills', skill), { recursive: true });
+    }
+    const dropped = ['story-understand-agent.md', 'story-executor-agent.md', 'story-pr-agent.md'];
+    for (const agent of dropped) fs.rmSync(path.join(claudeDir, 'agents', agent), { force: true });
+
+    const manifestPath = path.join(claudeDir, '.harness-manifest.json');
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    manifest.installedFiles = [
+      ...manifest.installedFiles.filter((f) => !dropped.some((d) => f === `agents/${d}`)),
+      ...ENTERPRISE_ONLY_SKILLS.map((s) => `skills/${s}/SKILL.md`),
+    ];
+    fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2), 'utf8');
+
+    runInstallJs(['--update', '--project', dir, ...LOCAL]);
+
+    const skills = fs.readdirSync(path.join(claudeDir, 'skills'));
+    for (const skill of ENTERPRISE_ONLY_SKILLS) {
+      assert.ok(!skills.includes(skill), `update should prune enterprise skill /${skill} from a solo install`);
+    }
+    const agents = fs.readdirSync(path.join(claudeDir, 'agents'));
+    for (const agent of dropped) {
+      assert.ok(agents.includes(agent), `update should restore ${agent} to a solo install`);
+    }
+    assert.equal(
+      JSON.parse(fs.readFileSync(manifestPath, 'utf8')).workflowPack, 'solo',
+      'pack must stay solo across the migration',
+    );
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }

--- a/install/__tests__/substitute.test.js
+++ b/install/__tests__/substitute.test.js
@@ -477,7 +477,9 @@ test('backfillManifest_DetectsEnterprisePackWhenEnterpriseAgentsPresent', () => 
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'backfill-test-'));
   try {
     fs.mkdirSync(path.join(dir, 'agents'), { recursive: true });
-    fs.writeFileSync(path.join(dir, 'agents', 'story-understand-agent.md'), '# test', 'utf8');
+    // story-plan-agent is enterprise-only; story-understand/-executor/-pr ship in
+    // both packs (solo's /implement spawns them), so they are not pack markers.
+    fs.writeFileSync(path.join(dir, 'agents', 'story-plan-agent.md'), '# test', 'utf8');
     const { detected } = backfillManifest(dir, { harnessVersion: '2.0.0' });
     assert.equal(detected.workflowPack, 'enterprise');
   } finally {

--- a/install/install.js
+++ b/install/install.js
@@ -19,7 +19,7 @@ const {
   isHarnessHook, reconcileSettings, verifyInstall, reportUnfilled, printDryRun,
   runCheck: runCheckImpl, runUpdate: runUpdateImpl,
   runSwitchTracker: runSwitchTrackerImpl, backfillManifest: backfillManifestImpl,
-  HARNESS_HOOK_SCRIPTS, ENTERPRISE_ONLY_AGENTS,
+  HARNESS_HOOK_SCRIPTS, ENTERPRISE_ONLY_AGENTS, ENTERPRISE_ONLY_SKILLS,
 } = require('./lib/updater.js');
 const { DEFAULT_REPO_URL } = require('./lib/source.js');
 
@@ -551,7 +551,8 @@ async function main() {
   }
 
   console.log('  Copying skills...');
-  installedFiles.push(...copyDirsWithLog(path.join(REPO_DIR, 'skills'), path.join(target, 'skills'), 'skills'));
+  const skillSkip = workflowPack === 'solo' ? ENTERPRISE_ONLY_SKILLS : null;
+  installedFiles.push(...copyDirsWithLog(path.join(REPO_DIR, 'skills'), path.join(target, 'skills'), 'skills', skillSkip));
 
   console.log(`  Copying tracker adapter (${tracker})...`);
   installedFiles.push(...copyGlob(path.join(REPO_DIR, 'trackers', tracker), path.join(target, 'trackers/active'), /\.sh$/, 'trackers/active'));

--- a/install/lib/copy.js
+++ b/install/lib/copy.js
@@ -6,11 +6,15 @@ const { walk } = require('../../hooks/lib/walk.js');
 
 const IS_WINDOWS = process.platform === 'win32';
 
-function copyDirsWithLog(srcRoot, destRoot, label) {
+function copyDirsWithLog(srcRoot, destRoot, label, skipSet = null) {
   const installed = [];
   if (!fs.existsSync(srcRoot)) return installed;
   for (const entry of fs.readdirSync(srcRoot, { withFileTypes: true })) {
     if (!entry.isDirectory()) continue;
+    if (skipSet && skipSet.has(entry.name)) {
+      console.log(`    Skipped:   ${label}/${entry.name} (enterprise-only)`);
+      continue;
+    }
     const destPath = path.join(destRoot, entry.name);
     const existed = fs.existsSync(destPath);
     console.log(`    ${existed ? 'Updating:  ' : 'Installing:'} ${label}/${entry.name}`);

--- a/install/lib/updater.js
+++ b/install/lib/updater.js
@@ -28,14 +28,23 @@ const HARNESS_HOOK_SCRIPTS = new Set([
   'tracker-sync.js',
 ]);
 
+// Agents only the enterprise pack's skills spawn. The story-understand / -executor
+// / -pr agents are NOT here: /implement and /run-tasks (both solo skills) spawn them
+// by name, so skipping them in solo left those skills pointing at agents that were
+// never installed.
 const ENTERPRISE_ONLY_AGENTS = new Set([
-  'story-understand-agent.md',
   'story-plan-agent.md',
-  'story-executor-agent.md',
-  'story-pr-agent.md',
   'sprint-plan-gap-analyzer.md',
   'sprint-plan-docs-reader.md',
   'sprint-plan-tracker-reader.md',
+]);
+
+// Skills that only exist in the enterprise pack. Previously every skill was copied
+// to every install, so solo users got /story and /sprint-plan — which spawn the
+// enterprise-only agents above and cannot work in a solo install.
+const ENTERPRISE_ONLY_SKILLS = new Set([
+  'story',
+  'sprint-plan',
 ]);
 
 function isHarnessHook(hookEntry) {
@@ -94,7 +103,14 @@ function verifyInstall(target, sedDirs, workflowPack = 'enterprise') {
   console.log('  Verifying installation...');
   let fail = 0;
   const required = [
-    ...(workflowPack === 'enterprise' ? ['skills/story/SKILL.md'] : ['skills/implement/SKILL.md']),
+    ...(workflowPack === 'enterprise'
+      ? ['skills/story/SKILL.md', 'agents/story-plan-agent.md']
+      : ['skills/implement/SKILL.md']),
+    // Spawned by /implement and /run-tasks, so required in BOTH packs.
+    'agents/story-understand-agent.md',
+    'agents/story-executor-agent.md',
+    'agents/story-pr-agent.md',
+    'agents/implement-planner-agent.md',
     'hooks/safety-check.js',
     'rules/code-style.md',
     'trackers/active/get-issue.sh',
@@ -113,6 +129,14 @@ function verifyInstall(target, sedDirs, workflowPack = 'enterprise') {
     if (fs.existsSync(path.join(target, name))) {
       console.log(`  [LEAKED]  ${name} — dev-only artefact found in install`);
       fail++;
+    }
+  }
+  if (workflowPack === 'solo') {
+    for (const skill of ENTERPRISE_ONLY_SKILLS) {
+      if (fs.existsSync(path.join(target, 'skills', skill))) {
+        console.log(`  [PACK]    skills/${skill} — enterprise-only skill in a solo install`);
+        fail++;
+      }
     }
   }
   if (fail === 0) console.log('  [OK] All critical files present, no dev artefacts leaked');
@@ -461,7 +485,21 @@ function runUpdate(target, { cliArgs = [], sourceDir = null, channelOverride = n
     fs.mkdirSync(path.join(target, d), { recursive: true });
   }
 
-  installedFiles.push(...copyDirsWithLog(path.join(src.dir, 'skills'), path.join(target, 'skills'), 'skills'));
+  const skillSkip = workflowPack === 'solo' ? ENTERPRISE_ONLY_SKILLS : null;
+  installedFiles.push(...copyDirsWithLog(path.join(src.dir, 'skills'), path.join(target, 'skills'), 'skills', skillSkip));
+
+  // Migrate: installs made before skills were pack-filtered carry enterprise-only
+  // skill directories. Per-file orphan removal empties them but leaves the dir, so
+  // prune the whole directory. Harness-managed path only; the snapshot backs it up.
+  if (skillSkip) {
+    for (const skill of skillSkip) {
+      const skillDir = path.join(target, 'skills', skill);
+      if (fs.existsSync(skillDir)) {
+        fs.rmSync(skillDir, { recursive: true, force: true });
+        console.log(`    Migrated: removed skills/${skill} (enterprise-only)`);
+      }
+    }
+  }
   installedFiles.push(...copyGlob(path.join(src.dir, 'trackers', tracker || 'github'), path.join(target, 'trackers/active'), /\.sh$/, 'trackers/active'));
   chmodExecutables(path.join(target, 'trackers/active'));
 
@@ -750,5 +788,5 @@ function backfillManifest(target, opts = {}) {
 module.exports = {
   isHarnessHook, reconcileSettings, verifyInstall, reportUnfilled, printDryRun,
   runCheck, runUpdate, runSwitchTracker, backfillManifest,
-  HARNESS_HOOK_SCRIPTS, ENTERPRISE_ONLY_AGENTS,
+  HARNESS_HOOK_SCRIPTS, ENTERPRISE_ONLY_AGENTS, ENTERPRISE_ONLY_SKILLS,
 };

--- a/rules/autonomous-mode.md
+++ b/rules/autonomous-mode.md
@@ -50,6 +50,14 @@ An autonomous run stops and asks the human on any of these, regardless of the se
 - **Scope change** — the work turns out materially larger or different than the approved brief/goal.
 - **3-failed-attempts** — the 3-attempt rule fires (route to `/debug`, which itself runs inherited-
   autonomous; see "How `/debug` behaves" below).
+- **Missing dependency** — a skill, agent, script, or tracker adapter the flow names by identity is
+  not installed. **Never substitute a replacement.** A named agent definition *is* a quality contract
+  (its system prompt encodes the planning structure, executor discipline, or review checklist the
+  phase depends on); swapping in a `general-purpose` agent with an improvised prompt silently changes
+  *what work was done*, not just how it was done — so it fails the reversibility test no matter how
+  close the substitute looks. Same for a missing skill or tracker script: stop and report the exact
+  missing identity and the phase that needed it. This is a harness defect, not a decision — route it
+  to `/improve-harness` once unblocked.
 
 A task **FAIL or BLOCKED** result also halts the run — that is a genuine block, not a checkpoint, and
 `--auto`'s "pause on failure" behavior is unchanged. `--autonomous` implies `--auto`.


### PR DESCRIPTION
## The bug

A solo-pack install shipped skills that spawn agents the same install never copied.

`/implement` and `/run-tasks` name three agents directly:

| Spawn site | Agent |
|---|---|
| `skills/implement/SKILL.md:220` — Phase 1 Understand | `story-understand-agent` |
| `skills/implement/SKILL.md:407` — Phase 3 Execute | `story-executor-agent` |
| `skills/implement/SKILL.md:492` — Phase 5 PR | `story-pr-agent` |
| `skills/run-tasks/SKILL.md:137` — resume | `story-executor-agent` |

All three sat on `ENTERPRISE_ONLY_AGENTS`, which the installer skips for solo. Skills were not pack-filtered at all, so solo installs *also* received `/story` and `/sprint-plan` — which depend on the enterprise-only agents and cannot run in a solo install.

The README's `/implement` walkthrough already described Phase 1 as "Spawns story-understand-agent (same agent as /story)", so the installer was the side that drifted from documented intent.

## The worse half

Discovered from a real autonomous run on a solo install: hitting a missing agent did **not** halt it. The run self-answered the gap — substituted `general-purpose` agents with improvised prompts for the understand phase, the task executors, and PR composition — and disclosed it only as three lines in the decisions log.

That passed the self-answer rule because "an agent I need doesn't exist" matched none of the pause-anyway triggers (contradiction / irreversible / scope change / 3-failed-attempts). It should not have. An agent definition **is** a quality contract — its system prompt encodes the 8-point brief structure, executor discipline, and PR checklist that the phase depends on. Replacing it changes *what work was done*, not just how, so it fails the reversibility test no matter how close the substitute looks.

## Changes

**Agent roster** — `story-understand-agent`, `story-executor-agent`, `story-pr-agent` now ship in both packs. `story-plan-agent` and the three `sprint-plan-*` agents stay enterprise-only and remain the pack-detection markers, so `backfillManifest` still identifies existing installs correctly.

**Skill filtering** — new `ENTERPRISE_ONLY_SKILLS` (`story`, `sprint-plan`); `copyDirsWithLog` takes a skip set. Per-file orphan removal alone left the empty skill *directories* behind on update, so `--update` also explicitly prunes them.

**Autonomous rule** — new **Missing dependency** pause-anyway trigger in `rules/autonomous-mode.md`, stating plainly that substituting a replacement is forbidden, and why.

**Drift guard** — `verifyInstall` now fails when a pack lacks an agent its skills spawn, or when an enterprise-only skill leaks into a solo install. This class of mismatch now fails at install time instead of surfacing mid-run.

## Verification

442 tests pass; lint and typecheck clean. Verified against real installs, not only unit tests:

| Case | Result |
|---|---|
| Fresh solo | 33 skills, no `/story` or `/sprint-plan`, all 3 story agents + `implement-planner-agent` present |
| Fresh enterprise | unchanged — both skills, all 7 story/sprint agents |
| Pre-fix solo → `--update` | prunes both skills, restores all 3 agents, pack stays `solo` |

New regression tests cover each case, including the migration path and a generic scan that reads every installed solo `SKILL.md`, extracts each agent it spawns by name, and asserts the definition exists — that catches the *next* roster drift, not just this instance.

One existing test used `story-understand-agent.md` as its enterprise-marker fixture; switched to `story-plan-agent.md`, which is still enterprise-only.

## Notes for review

- **PR #13 is not retroactively validated by this.** It was built with improvised agents; installing this fix and re-running the affected phases is the only way to know what those substitutions cost.
- README's skill table listed `/run-tasks` and `/babysit-pr` as enterprise-only, but both ship in each pack (`/run-tasks` is the documented resume path for `/implement`). Moved to Shared.

## Test plan

- [x] `npm test` — 442 pass
- [x] `npm run lint`, `npm run typecheck`
- [x] Fresh solo install — roster correct
- [x] Fresh enterprise install — unchanged
- [x] Pre-fix solo install → `--update` — migrates cleanly
- [ ] Re-run a `--autonomous` `/implement` on a solo install and confirm no agent substitution occurs
